### PR TITLE
Add OpenSSL test vectors &  Documentation

### DIFF
--- a/aws-lc-rs/src/cipher.rs
+++ b/aws-lc-rs/src/cipher.rs
@@ -643,7 +643,7 @@ mod tests {
     );
 
     cipher_test_vector!(
-        test_openssl_128_ctr_15_bytes,
+        test_openssl_aes_128_ctr_15_bytes,
         &AES_128_CTR,
         "244828580821c1652582c76e34d299f5",
         "093145d5af233f46072a5eb5adc11aa1",
@@ -652,7 +652,7 @@ mod tests {
     );
 
     cipher_test_vector!(
-        test_openssl_256_ctr_15_bytes,
+        test_openssl_aes_256_ctr_15_bytes,
         &AES_256_CTR,
         "0857db8240ea459bdf660b4cced66d1f2d3734ff2de7b81e92740e65e7cc6a1d",
         "f028ecb053f801102d11fccc9d303a27",


### PR DESCRIPTION
```
running 16 tests
test cipher::tests::test_encrypt_block_aes_256 ... ok
test cipher::tests::test_encrypt_block_aes_128 ... ok
test cipher::tests::test_iv_aes_128_ctr_16_bytes ... ok
test cipher::tests::test_iv_aes_128_cbc_16_bytes ... ok
test cipher::tests::test_iv_aes_256_ctr_15_bytes ... ok
test cipher::tests::test_openssl_aes_128_cbc_15_bytes ... ok
test cipher::tests::test_iv_aes_256_cbc_15_bytes ... ok
test cipher::tests::test_openssl_aes_128_ctr_15_bytes ... ok
test cipher::tests::test_openssl_aes_128_cbc_16_bytes ... ok
test cipher::tests::test_openssl_aes_256_cbc_16_bytes ... ok
test cipher::tests::test_openssl_aes_256_ctr_15_bytes ... ok
test cipher::tests::test_openssl_aes_256_cbc_15_bytes ... ok
test cipher::tests::test_aes_256_ctr ... ok
test cipher::tests::test_aes_256_cbc ... ok
test cipher::tests::test_aes_128_cbc ... ok
test cipher::tests::test_aes_128_ctr ... ok

test result: ok. 16 passed; 0 failed; 0 ignored; 0 measured; 87 filtered out; finished in 0.00s
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and 
the ISC license.
