### PR TITLE
Add opt-in 2TDEA and 3TDEA cipher support behind a `legacy-3des` feature

### DIFF
--- a/aws-lc-rs/Cargo.toml
+++ b/aws-lc-rs/Cargo.toml
@@ -39,6 +39,7 @@ test_logging = []
 unstable = []
 prebuilt-nasm = ["aws-lc-sys?/prebuilt-nasm"]
 dev-tests-only = []
+des = ["aws-lc-sys/all-bindings"]
 
 # require non-FIPS
 non-fips = ["aws-lc-sys"]

--- a/aws-lc-rs/Cargo.toml
+++ b/aws-lc-rs/Cargo.toml
@@ -39,7 +39,7 @@ test_logging = []
 unstable = []
 prebuilt-nasm = ["aws-lc-sys?/prebuilt-nasm"]
 dev-tests-only = []
-des = ["aws-lc-sys/all-bindings"]
+legacy-3des = ["aws-lc-sys?/all-bindings"]
 
 # require non-FIPS
 non-fips = ["aws-lc-sys"]

--- a/aws-lc-rs/README.md
+++ b/aws-lc-rs/README.md
@@ -124,6 +124,27 @@ It can be enabled in two ways:
 used in production builds. The `rand::unsealed` module and `mut_fill` method are not part of the
 stable public API and may change without notice.
 
+##### legacy-3des
+
+Enables Triple DES as an opt-in symmetric cipher under the `cipher` module, exposing
+both `DES_EDE_FOR_LEGACY_USE_ONLY` (2-key Triple DES / DES-EDE) and
+`DES_EDE3_FOR_LEGACY_USE_ONLY` (3-key Triple DES / DES-EDE3), together with the
+supporting key-length and IV-length constants. Only CBC and ECB operating modes are
+supported.
+
+**⚠️ Warning:** Triple DES is a legacy algorithm. It has been disallowed for
+encryption by [NIST SP 800-131A Rev. 2](https://csrc.nist.gov/publications/detail/sp/800-131a/rev-2/final):
+2-key Triple DES since 2015, and 3-key Triple DES after 2023. This feature exists
+solely to support interoperability with existing systems that cannot yet migrate to
+AES. All exposed items are marked `#[deprecated]` so that any use site produces a
+compiler warning. **Do not use Triple DES in new designs.** If you only need
+confidentiality, prefer AES-GCM or another AEAD from the `aead` module; if you
+specifically need a block cipher, prefer one of the AES algorithms in `cipher`.
+
+This feature also enables `aws-lc-sys?/all-bindings`, which is required to expose the
+`DES_*` bindings when the consuming build uses `bindgen` rather than the pre-generated
+bindings.
+
 ## Use of prebuilt NASM objects
 
 Prebuilt NASM objects are **only** applicable to Windows x86-64 platforms. They are **never** used on any other platform (Linux, macOS, etc.).

--- a/aws-lc-rs/src/aead/quic.rs
+++ b/aws-lc-rs/src/aead/quic.rs
@@ -163,6 +163,10 @@ fn cipher_new_mask(
             let counter = u32::from_ne_bytes(*counter_bytes).to_le();
             encrypt_block_chacha20(raw_key, input, nonce, counter)?
         }
+        #[cfg(feature = "des")]
+        SymmetricCipherKey::DesEde { .. } | SymmetricCipherKey::DesEde3 { .. } => {
+            return Err(error::Unspecified)
+        }
     };
 
     let mut out: [u8; 5] = [0; 5];

--- a/aws-lc-rs/src/aead/quic.rs
+++ b/aws-lc-rs/src/aead/quic.rs
@@ -71,7 +71,7 @@ pub type Sample = [u8; SAMPLE_LEN];
 
 /// A QUIC Header Protection Algorithm.
 pub struct Algorithm {
-    init: fn(key: &[u8]) -> Result<SymmetricCipherKey, error::Unspecified>,
+    init: fn(key: &[u8]) -> Result<SymmetricCipherKey, error::KeyRejected>,
 
     key_len: usize,
     id: AlgorithmID,
@@ -163,7 +163,7 @@ fn cipher_new_mask(
             let counter = u32::from_ne_bytes(*counter_bytes).to_le();
             encrypt_block_chacha20(raw_key, input, nonce, counter)?
         }
-        #[cfg(feature = "des")]
+        #[cfg(feature = "legacy-3des")]
         SymmetricCipherKey::DesEde { .. } | SymmetricCipherKey::DesEde3 { .. } => {
             return Err(error::Unspecified)
         }

--- a/aws-lc-rs/src/cipher.rs
+++ b/aws-lc-rs/src/cipher.rs
@@ -221,6 +221,8 @@
 pub(crate) mod aes;
 pub(crate) mod block;
 pub(crate) mod chacha;
+#[cfg(feature = "des")]
+pub(crate) mod des;
 pub(crate) mod key;
 mod padded;
 mod streaming;
@@ -233,10 +235,15 @@ use crate::aws_lc::{
     EVP_aes_192_cfb128, EVP_aes_192_ctr, EVP_aes_192_ecb, EVP_aes_256_cbc, EVP_aes_256_cfb128,
     EVP_aes_256_ctr, EVP_aes_256_ecb, EVP_CIPHER,
 };
+#[cfg(feature = "des")]
+use crate::aws_lc::{EVP_des_ede, EVP_des_ede3_cbc, EVP_des_ede3_ecb, EVP_des_ede_cbc};
 use crate::buffer::Buffer;
 use crate::error::Unspecified;
 use crate::hkdf;
 use crate::hkdf::KeyType;
+#[cfg(feature = "des")]
+#[allow(deprecated)]
+use crate::iv::IV_LEN_64_BIT;
 use crate::iv::{FixedLength, IV_LEN_128_BIT};
 use crate::ptr::ConstPointer;
 use core::fmt::Debug;
@@ -251,6 +258,16 @@ pub use crate::cipher::aes::AES_192_KEY_LEN;
 /// The number of bytes in an AES 256-bit key
 pub use crate::cipher::aes::AES_256_KEY_LEN;
 
+#[cfg(feature = "des")]
+/// The number of bytes in a 2TDEA (DES-EDE) key
+#[deprecated]
+pub use crate::cipher::des::DES_EDE_KEY_LEN;
+
+#[cfg(feature = "des")]
+/// The number of bytes in a 3TDEA (DES-EDE3) key
+#[deprecated]
+pub use crate::cipher::des::DES_EDE3_KEY_LEN;
+
 const MAX_CIPHER_KEY_LEN: usize = AES_256_KEY_LEN;
 
 /// The number of bytes for an AES-CBC initialization vector (IV)
@@ -262,7 +279,14 @@ pub use crate::cipher::aes::AES_CTR_IV_LEN;
 /// The number of bytes for an AES-CFB initialization vector (IV)
 pub use crate::cipher::aes::AES_CFB_IV_LEN;
 
+#[cfg(feature = "des")]
+#[deprecated]
+/// The number of bytes for a DES CBC initialization vector (IV)
+pub use crate::cipher::des::DES_CBC_IV_LEN;
+
 use crate::cipher::aes::AES_BLOCK_LEN;
+#[cfg(feature = "des")]
+use crate::cipher::des::DES_BLOCK_LEN;
 
 const MAX_CIPHER_BLOCK_LEN: usize = AES_BLOCK_LEN;
 
@@ -299,6 +323,20 @@ impl OperatingMode {
                 (OperatingMode::CTR, AlgorithmId::Aes256) => EVP_aes_256_ctr(),
                 (OperatingMode::CFB128, AlgorithmId::Aes256) => EVP_aes_256_cfb128(),
                 (OperatingMode::ECB, AlgorithmId::Aes256) => EVP_aes_256_ecb(),
+                #[cfg(feature = "des")]
+                #[allow(deprecated)]
+                (OperatingMode::CBC, AlgorithmId::DesEde) => EVP_des_ede_cbc(),
+                #[cfg(feature = "des")]
+                #[allow(deprecated)]
+                (OperatingMode::ECB, AlgorithmId::DesEde) => EVP_des_ede(),
+                #[cfg(feature = "des")]
+                #[allow(deprecated)]
+                (OperatingMode::CBC, AlgorithmId::DesEde3) => EVP_des_ede3_cbc(),
+                #[cfg(feature = "des")]
+                #[allow(deprecated)]
+                (OperatingMode::ECB, AlgorithmId::DesEde3) => EVP_des_ede3_ecb(),
+                #[cfg(feature = "des")]
+                _ => unreachable!(),
             })
             .unwrap()
         }
@@ -313,6 +351,11 @@ macro_rules! define_cipher_context {
             /// A 128-bit Initialization Vector.
             Iv128(FixedLength<IV_LEN_128_BIT>),
 
+            #[cfg(feature = "des")]
+            #[allow(deprecated)]
+            /// A 64-bit Initialization Vector (used by DES/3DES).
+            Iv64(FixedLength<IV_LEN_64_BIT>),
+
             /// No Cipher Context
             None,
         }
@@ -323,6 +366,8 @@ macro_rules! define_cipher_context {
             fn try_from(value: &'a $name) -> Result<Self, Unspecified> {
                 match value {
                     $name::Iv128(iv) => Ok(iv.as_ref()),
+                    #[cfg(feature = "des")]
+                    $name::Iv64(iv) => Ok(iv.as_ref()),
                     _ => Err(Unspecified),
                 }
             }
@@ -332,6 +377,8 @@ macro_rules! define_cipher_context {
             fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 match self {
                     Self::Iv128(_) => write!(f, "Iv128"),
+                    #[cfg(feature = "des")]
+                    Self::Iv64(_) => write!(f, "Iv64"),
                     Self::None => write!(f, "None"),
                 }
             }
@@ -341,6 +388,8 @@ macro_rules! define_cipher_context {
             fn from(value: $other) -> Self {
                 match value {
                     $other::Iv128(iv) => $name::Iv128(iv),
+                    #[cfg(feature = "des")]
+                    $other::Iv64(iv) => $name::Iv64(iv),
                     $other::None => $name::None,
                 }
             }
@@ -363,6 +412,16 @@ pub enum AlgorithmId {
 
     /// AES 192-bit
     Aes192,
+
+    /// 2TDEA
+    #[cfg(feature = "des")]
+    #[deprecated]
+    DesEde,
+
+    /// 3TDEA
+    #[cfg(feature = "des")]
+    #[deprecated]
+    DesEde3,
 }
 
 /// A cipher algorithm.
@@ -394,6 +453,26 @@ pub const AES_256: Algorithm = Algorithm {
     block_len: AES_BLOCK_LEN,
 };
 
+/// 2TDEA (DES-EDE) cipher
+#[cfg(feature = "des")]
+#[deprecated]
+pub const DES_EDE: Algorithm = Algorithm {
+    #[allow(deprecated)]
+    id: AlgorithmId::DesEde,
+    key_len: DES_EDE_KEY_LEN,
+    block_len: DES_BLOCK_LEN,
+};
+
+/// 3TDEA (DES-EDE3) cipher
+#[cfg(feature = "des")]
+#[deprecated]
+pub const DES_EDE3: Algorithm = Algorithm {
+    #[allow(deprecated)]
+    id: AlgorithmId::DesEde3,
+    key_len: DES_EDE3_KEY_LEN,
+    block_len: DES_BLOCK_LEN,
+};
+
 impl Algorithm {
     fn id(&self) -> &AlgorithmId {
         &self.id
@@ -417,6 +496,13 @@ impl Algorithm {
                 }
                 OperatingMode::ECB => Ok(EncryptionContext::None),
             },
+            #[cfg(feature = "des")]
+            #[allow(deprecated)]
+            AlgorithmId::DesEde | AlgorithmId::DesEde3 => match mode {
+                OperatingMode::CBC => Ok(EncryptionContext::Iv64(FixedLength::new()?)),
+                OperatingMode::ECB => Ok(EncryptionContext::None),
+                _ => Err(Unspecified),
+            },
         }
     }
 
@@ -431,6 +517,13 @@ impl Algorithm {
                     matches!(input, EncryptionContext::None)
                 }
             },
+            #[cfg(feature = "des")]
+            #[allow(deprecated)]
+            AlgorithmId::DesEde | AlgorithmId::DesEde3 => match mode {
+                OperatingMode::CBC => matches!(input, EncryptionContext::Iv64(_)),
+                OperatingMode::ECB => matches!(input, EncryptionContext::None),
+                _ => false,
+            },
         }
     }
 
@@ -444,6 +537,13 @@ impl Algorithm {
                 OperatingMode::ECB => {
                     matches!(input, DecryptionContext::None)
                 }
+            },
+            #[cfg(feature = "des")]
+            #[allow(deprecated)]
+            AlgorithmId::DesEde | AlgorithmId::DesEde3 => match mode {
+                OperatingMode::CBC => matches!(input, DecryptionContext::Iv64(_)),
+                OperatingMode::ECB => matches!(input, DecryptionContext::None),
+                _ => false,
             },
         }
     }
@@ -513,6 +613,12 @@ impl TryInto<SymmetricCipherKey> for UnboundCipherKey {
             AlgorithmId::Aes128 => SymmetricCipherKey::aes128(self.key_bytes.as_ref()),
             AlgorithmId::Aes192 => SymmetricCipherKey::aes192(self.key_bytes.as_ref()),
             AlgorithmId::Aes256 => SymmetricCipherKey::aes256(self.key_bytes.as_ref()),
+            #[cfg(feature = "des")]
+            #[allow(deprecated)]
+            AlgorithmId::DesEde => SymmetricCipherKey::des_ede(self.key_bytes.as_ref()),
+            #[cfg(feature = "des")]
+            #[allow(deprecated)]
+            AlgorithmId::DesEde3 => SymmetricCipherKey::des_ede3(self.key_bytes.as_ref()),
         }
     }
 }
@@ -797,21 +903,37 @@ fn encrypt(
             AlgorithmId::Aes128 | AlgorithmId::Aes192 | AlgorithmId::Aes256 => {
                 aes::encrypt_cbc_mode(key, context, in_out)
             }
+            #[cfg(feature = "des")]
+            #[allow(deprecated)]
+            AlgorithmId::DesEde | AlgorithmId::DesEde3 => {
+                des::encrypt_cbc_mode(key, context, in_out)
+            }
         },
         OperatingMode::CTR => match algorithm.id() {
             AlgorithmId::Aes128 | AlgorithmId::Aes192 | AlgorithmId::Aes256 => {
                 aes::encrypt_ctr_mode(key, context, in_out)
             }
+            #[cfg(feature = "des")]
+            #[allow(deprecated)]
+            AlgorithmId::DesEde | AlgorithmId::DesEde3 => Err(Unspecified),
         },
         // TODO: Hopefully support CFB1, and CFB8
         OperatingMode::CFB128 => match algorithm.id() {
             AlgorithmId::Aes128 | AlgorithmId::Aes192 | AlgorithmId::Aes256 => {
                 aes::encrypt_cfb_mode(key, mode, context, in_out)
             }
+            #[cfg(feature = "des")]
+            #[allow(deprecated)]
+            AlgorithmId::DesEde | AlgorithmId::DesEde3 => Err(Unspecified),
         },
         OperatingMode::ECB => match algorithm.id() {
             AlgorithmId::Aes128 | AlgorithmId::Aes192 | AlgorithmId::Aes256 => {
                 aes::encrypt_ecb_mode(key, context, in_out)
+            }
+            #[cfg(feature = "des")]
+            #[allow(deprecated)]
+            AlgorithmId::DesEde | AlgorithmId::DesEde3 => {
+                des::encrypt_ecb_mode(key, context, in_out)
             }
         },
     }
@@ -838,21 +960,37 @@ fn decrypt<'in_out>(
             AlgorithmId::Aes128 | AlgorithmId::Aes192 | AlgorithmId::Aes256 => {
                 aes::decrypt_cbc_mode(key, context, in_out)
             }
+            #[cfg(feature = "des")]
+            #[allow(deprecated)]
+            AlgorithmId::DesEde | AlgorithmId::DesEde3 => {
+                des::decrypt_cbc_mode(key, context, in_out)
+            }
         },
         OperatingMode::CTR => match algorithm.id() {
             AlgorithmId::Aes128 | AlgorithmId::Aes192 | AlgorithmId::Aes256 => {
                 aes::decrypt_ctr_mode(key, context, in_out)
             }
+            #[cfg(feature = "des")]
+            #[allow(deprecated)]
+            AlgorithmId::DesEde | AlgorithmId::DesEde3 => Err(Unspecified),
         },
         // TODO: Hopefully support CFB1, and CFB8
         OperatingMode::CFB128 => match algorithm.id() {
             AlgorithmId::Aes128 | AlgorithmId::Aes192 | AlgorithmId::Aes256 => {
                 aes::decrypt_cfb_mode(key, mode, context, in_out)
             }
+            #[cfg(feature = "des")]
+            #[allow(deprecated)]
+            AlgorithmId::DesEde | AlgorithmId::DesEde3 => Err(Unspecified),
         },
         OperatingMode::ECB => match algorithm.id() {
             AlgorithmId::Aes128 | AlgorithmId::Aes192 | AlgorithmId::Aes256 => {
                 aes::decrypt_ecb_mode(key, context, in_out)
+            }
+            #[cfg(feature = "des")]
+            #[allow(deprecated)]
+            AlgorithmId::DesEde | AlgorithmId::DesEde3 => {
+                des::decrypt_ecb_mode(key, context, in_out)
             }
         },
     }
@@ -1189,5 +1327,124 @@ mod tests {
         "000102030405060708090a0b0c0d0e0f",
         "6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e5130c81c46a35ce411e5fbc1191a0a52eff69f2445df4f9b17ad2b417be66c3710",
         "f58c4c04d6e5f1ba779eabfb5f7bfbd69cfc4e967edb808d679f777bc6702c7d39f23369a9d9bacfa530e26304231461b2eb05e2c39be9fcda6c19078c6a9d1b"
+    );
+
+    #[cfg(feature = "des")]
+    #[test]
+    #[allow(deprecated)]
+    fn test_des_ede_cbc() {
+        let key = from_hex("0123456789abcdef23456789abcdef01").unwrap();
+        for i in 1..=3 {
+            let size = i * 8;
+            helper_test_cipher_n_bytes(key.as_slice(), &DES_EDE, OperatingMode::CBC, size);
+        }
+    }
+
+    #[cfg(feature = "des")]
+    #[allow(deprecated)]
+    #[test]
+    fn test_des_ede_ecb() {
+        let key = from_hex("0123456789abcdef23456789abcdef01").unwrap();
+        for i in 1..=3 {
+            let size = i * 8;
+            helper_test_cipher_n_bytes(key.as_slice(), &DES_EDE, OperatingMode::ECB, size);
+        }
+    }
+
+    #[cfg(feature = "des")]
+    #[test]
+    #[allow(deprecated)]
+    fn test_des_ede3_cbc() {
+        let key = from_hex("0123456789abcdef23456789abcdef01456789abcdef0123").unwrap();
+        for i in 1..=3 {
+            let size = i * 8;
+            helper_test_cipher_n_bytes(key.as_slice(), &DES_EDE3, OperatingMode::CBC, size);
+        }
+    }
+
+    #[cfg(feature = "des")]
+    #[test]
+    #[allow(deprecated)]
+    fn test_des_ede3_ecb() {
+        let key = from_hex("0123456789abcdef23456789abcdef01456789abcdef0123").unwrap();
+        for i in 1..=3 {
+            let size = i * 8;
+            helper_test_cipher_n_bytes(key.as_slice(), &DES_EDE3, OperatingMode::ECB, size);
+        }
+    }
+
+    #[cfg(feature = "des")]
+    macro_rules! des_cipher_kat {
+        ($name:ident, $alg:expr, $mode:expr, $key:literal, $iv:literal, $plaintext:literal, $ciphertext:literal) => {
+            #[allow(deprecated)]
+            #[test]
+            fn $name() {
+                let key = from_hex($key).unwrap();
+                let input = from_hex($plaintext).unwrap();
+                let expected_ciphertext = from_hex($ciphertext).unwrap();
+
+                let ec = if $iv.len() == 0 {
+                    EncryptionContext::None
+                } else {
+                    let iv_arr: [u8; 8] = from_hex($iv).unwrap().try_into().unwrap();
+                    EncryptionContext::Iv64(FixedLength::from(iv_arr))
+                };
+
+                let unbound_key = UnboundCipherKey::new($alg, &key).unwrap();
+                let encrypting_key = EncryptingKey::new(unbound_key, $mode).unwrap();
+                let mut in_out = input.clone();
+                let context = encrypting_key.less_safe_encrypt(&mut in_out, ec).unwrap();
+                assert_eq!(expected_ciphertext, in_out);
+
+                let unbound_key2 = UnboundCipherKey::new($alg, &key).unwrap();
+                let decrypting_key = DecryptingKey::new(unbound_key2, $mode).unwrap();
+                let plaintext = decrypting_key.decrypt(&mut in_out, context).unwrap();
+                assert_eq!(input.as_slice(), plaintext);
+            }
+        };
+    }
+
+    #[cfg(feature = "des")]
+    des_cipher_kat!(
+        test_sp800_67_des_ede_cbc,
+        &DES_EDE,
+        OperatingMode::CBC,
+        "0123456789abcdef23456789abcdef01",
+        "f69f2445df4f9b17",
+        "6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e51",
+        "7401CE1EAB6D003CAFF84BF47B36CC2154F0238F9FFECD8F6ACF118392B45581"
+    );
+
+    #[cfg(feature = "des")]
+    des_cipher_kat!(
+        test_sp800_67_des_ede_ecb,
+        &DES_EDE,
+        OperatingMode::ECB,
+        "0123456789abcdef23456789abcdef01",
+        "",
+        "6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e51",
+        "06EDE3D82884090AFF322C19F0518486730576972A666E58B6C88CF107340D3D"
+    );
+
+    #[cfg(feature = "des")]
+    des_cipher_kat!(
+        test_sp800_67_des_ede3_cbc,
+        &DES_EDE3,
+        OperatingMode::CBC,
+        "0123456789abcdef23456789abcdef01456789abcdef0123",
+        "f69f2445df4f9b17",
+        "6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e51",
+        "2079c3d53aa763e193b79e2569ab5262516570481f25b50f73c0bda85c8e0da7"
+    );
+
+    #[cfg(feature = "des")]
+    des_cipher_kat!(
+        test_sp800_67_des_ede3_ecb,
+        &DES_EDE3,
+        OperatingMode::ECB,
+        "0123456789abcdef23456789abcdef01456789abcdef0123",
+        "",
+        "6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e51",
+        "714772f339841d34267fcc4bd2949cc3ee11c22a576a303876183f99c0b6de87"
     );
 }

--- a/aws-lc-rs/src/cipher.rs
+++ b/aws-lc-rs/src/cipher.rs
@@ -221,7 +221,7 @@
 pub(crate) mod aes;
 pub(crate) mod block;
 pub(crate) mod chacha;
-#[cfg(feature = "des")]
+#[cfg(feature = "legacy-3des")]
 pub(crate) mod des;
 pub(crate) mod key;
 mod padded;
@@ -235,14 +235,13 @@ use crate::aws_lc::{
     EVP_aes_192_cfb128, EVP_aes_192_ctr, EVP_aes_192_ecb, EVP_aes_256_cbc, EVP_aes_256_cfb128,
     EVP_aes_256_ctr, EVP_aes_256_ecb, EVP_CIPHER,
 };
-#[cfg(feature = "des")]
+#[cfg(feature = "legacy-3des")]
 use crate::aws_lc::{EVP_des_ede, EVP_des_ede3_cbc, EVP_des_ede3_ecb, EVP_des_ede_cbc};
 use crate::buffer::Buffer;
-use crate::error::Unspecified;
+use crate::error::{KeyRejected, Unspecified};
 use crate::hkdf;
 use crate::hkdf::KeyType;
-#[cfg(feature = "des")]
-#[allow(deprecated)]
+#[cfg(feature = "legacy-3des")]
 use crate::iv::IV_LEN_64_BIT;
 use crate::iv::{FixedLength, IV_LEN_128_BIT};
 use crate::ptr::ConstPointer;
@@ -258,14 +257,24 @@ pub use crate::cipher::aes::AES_192_KEY_LEN;
 /// The number of bytes in an AES 256-bit key
 pub use crate::cipher::aes::AES_256_KEY_LEN;
 
-#[cfg(feature = "des")]
-/// The number of bytes in a 2TDEA (DES-EDE) key
-#[deprecated]
+/// The number of bytes in a 2TDEA (DES-EDE, 2-key Triple DES) key.
+///
+/// 2-key Triple DES is a legacy algorithm and has been disallowed for encryption
+/// by NIST SP 800-131A Rev. 2 since 2015. It is retained for interoperability only.
+#[cfg(feature = "legacy-3des")]
+#[deprecated(
+    note = "2-key Triple DES is a legacy algorithm retained for interoperability only; NIST SP 800-131A Rev. 2 disallows its use for encryption. Prefer an AES-based algorithm."
+)]
 pub use crate::cipher::des::DES_EDE_KEY_LEN;
 
-#[cfg(feature = "des")]
-/// The number of bytes in a 3TDEA (DES-EDE3) key
-#[deprecated]
+/// The number of bytes in a 3TDEA (DES-EDE3, 3-key Triple DES) key.
+///
+/// 3DES is a legacy algorithm and has been disallowed for encryption by
+/// NIST SP 800-131A Rev. 2 after 2023. It is retained for interoperability only.
+#[cfg(feature = "legacy-3des")]
+#[deprecated(
+    note = "3DES is a legacy algorithm retained for interoperability only; NIST SP 800-131A Rev. 2 disallows its use for encryption. Prefer an AES-based algorithm."
+)]
 pub use crate::cipher::des::DES_EDE3_KEY_LEN;
 
 const MAX_CIPHER_KEY_LEN: usize = AES_256_KEY_LEN;
@@ -279,13 +288,18 @@ pub use crate::cipher::aes::AES_CTR_IV_LEN;
 /// The number of bytes for an AES-CFB initialization vector (IV)
 pub use crate::cipher::aes::AES_CFB_IV_LEN;
 
-#[cfg(feature = "des")]
-#[deprecated]
-/// The number of bytes for a DES CBC initialization vector (IV)
+/// The number of bytes for a 3DES-CBC initialization vector (IV).
+///
+/// 3DES is a legacy algorithm and has been disallowed for encryption by
+/// NIST SP 800-131A Rev. 2 after 2023. It is retained for interoperability only.
+#[cfg(feature = "legacy-3des")]
+#[deprecated(
+    note = "3DES is a legacy algorithm retained for interoperability only; NIST SP 800-131A Rev. 2 disallows its use for encryption. Prefer an AES-based algorithm."
+)]
 pub use crate::cipher::des::DES_CBC_IV_LEN;
 
 use crate::cipher::aes::AES_BLOCK_LEN;
-#[cfg(feature = "des")]
+#[cfg(feature = "legacy-3des")]
 use crate::cipher::des::DES_BLOCK_LEN;
 
 const MAX_CIPHER_BLOCK_LEN: usize = AES_BLOCK_LEN;
@@ -309,37 +323,44 @@ pub enum OperatingMode {
 
 impl OperatingMode {
     fn evp_cipher(&self, algorithm: &Algorithm) -> ConstPointer<'_, EVP_CIPHER> {
-        unsafe {
-            ConstPointer::new_static(match (self, algorithm.id) {
-                (OperatingMode::CBC, AlgorithmId::Aes128) => EVP_aes_128_cbc(),
-                (OperatingMode::CTR, AlgorithmId::Aes128) => EVP_aes_128_ctr(),
-                (OperatingMode::CFB128, AlgorithmId::Aes128) => EVP_aes_128_cfb128(),
-                (OperatingMode::ECB, AlgorithmId::Aes128) => EVP_aes_128_ecb(),
-                (OperatingMode::CBC, AlgorithmId::Aes192) => EVP_aes_192_cbc(),
-                (OperatingMode::CTR, AlgorithmId::Aes192) => EVP_aes_192_ctr(),
-                (OperatingMode::CFB128, AlgorithmId::Aes192) => EVP_aes_192_cfb128(),
-                (OperatingMode::ECB, AlgorithmId::Aes192) => EVP_aes_192_ecb(),
-                (OperatingMode::CBC, AlgorithmId::Aes256) => EVP_aes_256_cbc(),
-                (OperatingMode::CTR, AlgorithmId::Aes256) => EVP_aes_256_ctr(),
-                (OperatingMode::CFB128, AlgorithmId::Aes256) => EVP_aes_256_cfb128(),
-                (OperatingMode::ECB, AlgorithmId::Aes256) => EVP_aes_256_ecb(),
-                #[cfg(feature = "des")]
-                #[allow(deprecated)]
-                (OperatingMode::CBC, AlgorithmId::DesEde) => EVP_des_ede_cbc(),
-                #[cfg(feature = "des")]
-                #[allow(deprecated)]
-                (OperatingMode::ECB, AlgorithmId::DesEde) => EVP_des_ede(),
-                #[cfg(feature = "des")]
-                #[allow(deprecated)]
-                (OperatingMode::CBC, AlgorithmId::DesEde3) => EVP_des_ede3_cbc(),
-                #[cfg(feature = "des")]
-                #[allow(deprecated)]
-                (OperatingMode::ECB, AlgorithmId::DesEde3) => EVP_des_ede3_ecb(),
-                #[cfg(feature = "des")]
-                _ => unreachable!(),
-            })
-            .unwrap()
-        }
+        let alg = match (self, algorithm.id) {
+            (OperatingMode::CBC, AlgorithmId::Aes128) => unsafe { EVP_aes_128_cbc() },
+            (OperatingMode::CTR, AlgorithmId::Aes128) => unsafe { EVP_aes_128_ctr() },
+            (OperatingMode::CFB128, AlgorithmId::Aes128) => unsafe { EVP_aes_128_cfb128() },
+            (OperatingMode::ECB, AlgorithmId::Aes128) => unsafe { EVP_aes_128_ecb() },
+            (OperatingMode::CBC, AlgorithmId::Aes192) => unsafe { EVP_aes_192_cbc() },
+            (OperatingMode::CTR, AlgorithmId::Aes192) => unsafe { EVP_aes_192_ctr() },
+            (OperatingMode::CFB128, AlgorithmId::Aes192) => unsafe { EVP_aes_192_cfb128() },
+            (OperatingMode::ECB, AlgorithmId::Aes192) => unsafe { EVP_aes_192_ecb() },
+            (OperatingMode::CBC, AlgorithmId::Aes256) => unsafe { EVP_aes_256_cbc() },
+            (OperatingMode::CTR, AlgorithmId::Aes256) => unsafe { EVP_aes_256_ctr() },
+            (OperatingMode::CFB128, AlgorithmId::Aes256) => unsafe { EVP_aes_256_cfb128() },
+            (OperatingMode::ECB, AlgorithmId::Aes256) => unsafe { EVP_aes_256_ecb() },
+            #[cfg(feature = "legacy-3des")]
+            (OperatingMode::CBC, AlgorithmId::DesEdeForLegacyUseOnly) => unsafe {
+                EVP_des_ede_cbc()
+            },
+            #[cfg(feature = "legacy-3des")]
+            (OperatingMode::ECB, AlgorithmId::DesEdeForLegacyUseOnly) => unsafe { EVP_des_ede() },
+            #[cfg(feature = "legacy-3des")]
+            (OperatingMode::CBC, AlgorithmId::DesEde3ForLegacyUseOnly) => unsafe {
+                EVP_des_ede3_cbc()
+            },
+            #[cfg(feature = "legacy-3des")]
+            (OperatingMode::ECB, AlgorithmId::DesEde3ForLegacyUseOnly) => unsafe {
+                EVP_des_ede3_ecb()
+            },
+            #[cfg(feature = "legacy-3des")]
+            (OperatingMode::CTR, AlgorithmId::DesEdeForLegacyUseOnly)
+            | (OperatingMode::CTR, AlgorithmId::DesEde3ForLegacyUseOnly)
+            | (OperatingMode::CFB128, AlgorithmId::DesEdeForLegacyUseOnly)
+            | (OperatingMode::CFB128, AlgorithmId::DesEde3ForLegacyUseOnly) => {
+                // `supports_mode()` rejects these combinations at key-construction
+                // time, so this branch is unreachable in practice.
+                unreachable!("DES does not support CTR or CFB128 modes")
+            }
+        };
+        unsafe { ConstPointer::new_static(alg).unwrap() }
     }
 }
 
@@ -351,9 +372,8 @@ macro_rules! define_cipher_context {
             /// A 128-bit Initialization Vector.
             Iv128(FixedLength<IV_LEN_128_BIT>),
 
-            #[cfg(feature = "des")]
-            #[allow(deprecated)]
-            /// A 64-bit Initialization Vector (used by DES/3DES).
+            /// A 64-bit Initialization Vector (used by 3DES).
+            #[cfg(feature = "legacy-3des")]
             Iv64(FixedLength<IV_LEN_64_BIT>),
 
             /// No Cipher Context
@@ -366,7 +386,7 @@ macro_rules! define_cipher_context {
             fn try_from(value: &'a $name) -> Result<Self, Unspecified> {
                 match value {
                     $name::Iv128(iv) => Ok(iv.as_ref()),
-                    #[cfg(feature = "des")]
+                    #[cfg(feature = "legacy-3des")]
                     $name::Iv64(iv) => Ok(iv.as_ref()),
                     _ => Err(Unspecified),
                 }
@@ -377,7 +397,7 @@ macro_rules! define_cipher_context {
             fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 match self {
                     Self::Iv128(_) => write!(f, "Iv128"),
-                    #[cfg(feature = "des")]
+                    #[cfg(feature = "legacy-3des")]
                     Self::Iv64(_) => write!(f, "Iv64"),
                     Self::None => write!(f, "None"),
                 }
@@ -388,7 +408,7 @@ macro_rules! define_cipher_context {
             fn from(value: $other) -> Self {
                 match value {
                     $other::Iv128(iv) => $name::Iv128(iv),
-                    #[cfg(feature = "des")]
+                    #[cfg(feature = "legacy-3des")]
                     $other::Iv64(iv) => $name::Iv64(iv),
                     $other::None => $name::None,
                 }
@@ -413,15 +433,19 @@ pub enum AlgorithmId {
     /// AES 192-bit
     Aes192,
 
-    /// 2TDEA
-    #[cfg(feature = "des")]
-    #[deprecated]
-    DesEde,
+    /// 2TDEA (for legacy use only).
+    ///
+    /// 2-key Triple DES has been disallowed for encryption by
+    /// NIST SP 800-131A Rev. 2 since 2015.
+    #[cfg(feature = "legacy-3des")]
+    DesEdeForLegacyUseOnly,
 
-    /// 3TDEA
-    #[cfg(feature = "des")]
-    #[deprecated]
-    DesEde3,
+    /// 3TDEA (for legacy use only).
+    ///
+    /// 3DES has been disallowed for encryption by NIST SP 800-131A Rev. 2
+    /// after 2023.
+    #[cfg(feature = "legacy-3des")]
+    DesEde3ForLegacyUseOnly,
 }
 
 /// A cipher algorithm.
@@ -453,22 +477,49 @@ pub const AES_256: Algorithm = Algorithm {
     block_len: AES_BLOCK_LEN,
 };
 
-/// 2TDEA (DES-EDE) cipher
-#[cfg(feature = "des")]
-#[deprecated]
-pub const DES_EDE: Algorithm = Algorithm {
-    #[allow(deprecated)]
-    id: AlgorithmId::DesEde,
+/// 2TDEA (DES-EDE, 2-key Triple DES) cipher, for legacy interoperability only.
+///
+/// 2-key Triple DES is a legacy algorithm and has been disallowed for encryption
+/// by [NIST SP 800-131A Rev. 2](https://csrc.nist.gov/publications/detail/sp/800-131a/rev-2/final)
+/// since 2015 — several years earlier than 3-key Triple DES. It is retained here
+/// solely for interoperability with existing systems that cannot yet migrate.
+/// New designs must use an AES-based algorithm.
+///
+/// Only CBC and ECB operating modes are supported. K1 must differ from K2; if
+/// they are equal the cipher degenerates to single-DES and key construction
+/// will fail.
+#[cfg(feature = "legacy-3des")]
+#[allow(deprecated)]
+#[deprecated(
+    note = "2-key Triple DES is a legacy algorithm retained for interoperability only; NIST SP 800-131A Rev. 2 disallows its use for encryption. Prefer an AES-based algorithm."
+)]
+pub const DES_EDE_FOR_LEGACY_USE_ONLY: Algorithm = Algorithm {
+    id: AlgorithmId::DesEdeForLegacyUseOnly,
     key_len: DES_EDE_KEY_LEN,
     block_len: DES_BLOCK_LEN,
 };
 
-/// 3TDEA (DES-EDE3) cipher
-#[cfg(feature = "des")]
-#[deprecated]
-pub const DES_EDE3: Algorithm = Algorithm {
-    #[allow(deprecated)]
-    id: AlgorithmId::DesEde3,
+/// 3TDEA (DES-EDE3, 3-key Triple DES) cipher, for legacy interoperability only.
+///
+/// 3DES is a legacy algorithm and has been disallowed for encryption by
+/// [NIST SP 800-131A Rev. 2](https://csrc.nist.gov/publications/detail/sp/800-131a/rev-2/final)
+/// after 2023. It is retained here solely for interoperability with existing
+/// systems that cannot yet migrate. New designs must use an AES-based algorithm.
+///
+/// Only CBC and ECB operating modes are supported. K1, K2, and K3 must all
+/// be distinct; any pairwise equality causes 3TDEA to degenerate (to either
+/// single-DES or 2TDEA) and is rejected at key construction time.
+///
+/// Callers who specifically need 2-key Triple DES (2TDEA) must use
+/// [`DES_EDE_FOR_LEGACY_USE_ONLY`] (16-byte key) rather than encoding 2TDEA
+/// as a 24-byte `K1 ‖ K2 ‖ K1` key here.
+#[cfg(feature = "legacy-3des")]
+#[allow(deprecated)]
+#[deprecated(
+    note = "3DES is a legacy algorithm retained for interoperability only; NIST SP 800-131A Rev. 2 disallows its use for encryption. Prefer an AES-based algorithm."
+)]
+pub const DES_EDE3_FOR_LEGACY_USE_ONLY: Algorithm = Algorithm {
+    id: AlgorithmId::DesEde3ForLegacyUseOnly,
     key_len: DES_EDE3_KEY_LEN,
     block_len: DES_BLOCK_LEN,
 };
@@ -496,13 +547,14 @@ impl Algorithm {
                 }
                 OperatingMode::ECB => Ok(EncryptionContext::None),
             },
-            #[cfg(feature = "des")]
-            #[allow(deprecated)]
-            AlgorithmId::DesEde | AlgorithmId::DesEde3 => match mode {
-                OperatingMode::CBC => Ok(EncryptionContext::Iv64(FixedLength::new()?)),
-                OperatingMode::ECB => Ok(EncryptionContext::None),
-                _ => Err(Unspecified),
-            },
+            #[cfg(feature = "legacy-3des")]
+            AlgorithmId::DesEdeForLegacyUseOnly | AlgorithmId::DesEde3ForLegacyUseOnly => {
+                match mode {
+                    OperatingMode::CBC => Ok(EncryptionContext::Iv64(FixedLength::new()?)),
+                    OperatingMode::ECB => Ok(EncryptionContext::None),
+                    _ => Err(Unspecified),
+                }
+            }
         }
     }
 
@@ -517,13 +569,14 @@ impl Algorithm {
                     matches!(input, EncryptionContext::None)
                 }
             },
-            #[cfg(feature = "des")]
-            #[allow(deprecated)]
-            AlgorithmId::DesEde | AlgorithmId::DesEde3 => match mode {
-                OperatingMode::CBC => matches!(input, EncryptionContext::Iv64(_)),
-                OperatingMode::ECB => matches!(input, EncryptionContext::None),
-                _ => false,
-            },
+            #[cfg(feature = "legacy-3des")]
+            AlgorithmId::DesEdeForLegacyUseOnly | AlgorithmId::DesEde3ForLegacyUseOnly => {
+                match mode {
+                    OperatingMode::CBC => matches!(input, EncryptionContext::Iv64(_)),
+                    OperatingMode::ECB => matches!(input, EncryptionContext::None),
+                    _ => false,
+                }
+            }
         }
     }
 
@@ -538,13 +591,35 @@ impl Algorithm {
                     matches!(input, DecryptionContext::None)
                 }
             },
-            #[cfg(feature = "des")]
-            #[allow(deprecated)]
-            AlgorithmId::DesEde | AlgorithmId::DesEde3 => match mode {
-                OperatingMode::CBC => matches!(input, DecryptionContext::Iv64(_)),
-                OperatingMode::ECB => matches!(input, DecryptionContext::None),
-                _ => false,
-            },
+            #[cfg(feature = "legacy-3des")]
+            AlgorithmId::DesEdeForLegacyUseOnly | AlgorithmId::DesEde3ForLegacyUseOnly => {
+                match mode {
+                    OperatingMode::CBC => matches!(input, DecryptionContext::Iv64(_)),
+                    OperatingMode::ECB => matches!(input, DecryptionContext::None),
+                    _ => false,
+                }
+            }
+        }
+    }
+
+    /// Returns `true` if the algorithm supports the given operating mode.
+    ///
+    /// Used to reject invalid `(algorithm, mode)` combinations (e.g. DES with
+    /// CTR or CFB128) at key-construction time rather than deferring the
+    /// failure to the first encrypt/decrypt call.
+    fn supports_mode(&self, mode: OperatingMode) -> bool {
+        match self.id {
+            AlgorithmId::Aes128 | AlgorithmId::Aes192 | AlgorithmId::Aes256 => matches!(
+                mode,
+                OperatingMode::CBC
+                    | OperatingMode::CTR
+                    | OperatingMode::CFB128
+                    | OperatingMode::ECB
+            ),
+            #[cfg(feature = "legacy-3des")]
+            AlgorithmId::DesEdeForLegacyUseOnly | AlgorithmId::DesEde3ForLegacyUseOnly => {
+                matches!(mode, OperatingMode::CBC | OperatingMode::ECB)
+            }
         }
     }
 }
@@ -603,22 +678,50 @@ impl UnboundCipherKey {
     pub fn algorithm(&self) -> &'static Algorithm {
         self.algorithm
     }
+
+    /// Validates the key material against algorithm-specific constraints beyond
+    /// the length check performed by [`UnboundCipherKey::new`].
+    ///
+    /// For DES algorithms (behind `legacy-3des`), this rejects weak DES subkeys
+    /// and degenerate key configurations (e.g. K1 == K2 for 2TDEA). For other
+    /// algorithms this is a no-op since the only constraint is key length.
+    ///
+    /// The streaming cipher constructors call this because they pass raw key
+    /// bytes directly to the EVP API rather than going through
+    /// [`SymmetricCipherKey`] construction, which would otherwise perform these
+    /// checks. This is necessary because the EVP layer internally uses
+    /// `DES_set_key_unchecked`, which skips weak-key detection.
+    fn validate_key_material(&self) -> Result<(), KeyRejected> {
+        #[cfg(feature = "legacy-3des")]
+        match self.algorithm.id() {
+            AlgorithmId::DesEdeForLegacyUseOnly => {
+                let _ = SymmetricCipherKey::prepare_des_ede(self.key_bytes.as_ref())?;
+            }
+            AlgorithmId::DesEde3ForLegacyUseOnly => {
+                let _ = SymmetricCipherKey::prepare_des_ede3(self.key_bytes.as_ref())?;
+            }
+            _ => {}
+        }
+        Ok(())
+    }
 }
 
 impl TryInto<SymmetricCipherKey> for UnboundCipherKey {
-    type Error = Unspecified;
+    type Error = KeyRejected;
 
     fn try_into(self) -> Result<SymmetricCipherKey, Self::Error> {
         match self.algorithm.id() {
             AlgorithmId::Aes128 => SymmetricCipherKey::aes128(self.key_bytes.as_ref()),
             AlgorithmId::Aes192 => SymmetricCipherKey::aes192(self.key_bytes.as_ref()),
             AlgorithmId::Aes256 => SymmetricCipherKey::aes256(self.key_bytes.as_ref()),
-            #[cfg(feature = "des")]
-            #[allow(deprecated)]
-            AlgorithmId::DesEde => SymmetricCipherKey::des_ede(self.key_bytes.as_ref()),
-            #[cfg(feature = "des")]
-            #[allow(deprecated)]
-            AlgorithmId::DesEde3 => SymmetricCipherKey::des_ede3(self.key_bytes.as_ref()),
+            #[cfg(feature = "legacy-3des")]
+            AlgorithmId::DesEdeForLegacyUseOnly => {
+                SymmetricCipherKey::des_ede(self.key_bytes.as_ref())
+            }
+            #[cfg(feature = "legacy-3des")]
+            AlgorithmId::DesEde3ForLegacyUseOnly => {
+                SymmetricCipherKey::des_ede3(self.key_bytes.as_ref())
+            }
         }
     }
 }
@@ -668,6 +771,9 @@ impl EncryptingKey {
     // * `AES_128`
     // * `AES_256`
     //
+    // `DES_EDE_FOR_LEGACY_USE_ONLY` and `DES_EDE3_FOR_LEGACY_USE_ONLY` are never
+    // FIPS-approved.
+    //
     /// # Errors
     /// * [`Unspecified`]: Returned if there is an error constructing the `EncryptingKey`.
     pub fn cbc(key: UnboundCipherKey) -> Result<Self, Unspecified> {
@@ -685,6 +791,9 @@ impl EncryptingKey {
     // * `AES_128`
     // * `AES_256`
     //
+    // `DES_EDE_FOR_LEGACY_USE_ONLY` and `DES_EDE3_FOR_LEGACY_USE_ONLY` are never
+    // FIPS-approved.
+    //
     /// # Errors
     /// * [`Unspecified`]: Returned if there is an error constructing the `EncryptingKey`.
     pub fn ecb(key: UnboundCipherKey) -> Result<Self, Unspecified> {
@@ -694,6 +803,9 @@ impl EncryptingKey {
     #[allow(clippy::unnecessary_wraps)]
     fn new(key: UnboundCipherKey, mode: OperatingMode) -> Result<Self, Unspecified> {
         let algorithm = key.algorithm();
+        if !algorithm.supports_mode(mode) {
+            return Err(Unspecified);
+        }
         let key = key.try_into()?;
         Ok(Self {
             algorithm,
@@ -809,6 +921,9 @@ impl DecryptingKey {
     // * `AES_128`
     // * `AES_256`
     //
+    // `DES_EDE_FOR_LEGACY_USE_ONLY` and `DES_EDE3_FOR_LEGACY_USE_ONLY` are never
+    // FIPS-approved.
+    //
     /// # Errors
     /// * [`Unspecified`]: Returned if there is an error during decryption.
     pub fn cbc(key: UnboundCipherKey) -> Result<DecryptingKey, Unspecified> {
@@ -826,6 +941,9 @@ impl DecryptingKey {
     // * `AES_128`
     // * `AES_256`
     //
+    // `DES_EDE_FOR_LEGACY_USE_ONLY` and `DES_EDE3_FOR_LEGACY_USE_ONLY` are never
+    // FIPS-approved.
+    //
     /// # Errors
     /// * [`Unspecified`]: Returned if there is an error constructing the `DecryptingKey`.
     pub fn ecb(key: UnboundCipherKey) -> Result<Self, Unspecified> {
@@ -835,6 +953,9 @@ impl DecryptingKey {
     #[allow(clippy::unnecessary_wraps)]
     fn new(key: UnboundCipherKey, mode: OperatingMode) -> Result<Self, Unspecified> {
         let algorithm = key.algorithm();
+        if !algorithm.supports_mode(mode) {
+            return Err(Unspecified);
+        }
         let key = key.try_into()?;
         Ok(Self {
             algorithm,
@@ -903,9 +1024,8 @@ fn encrypt(
             AlgorithmId::Aes128 | AlgorithmId::Aes192 | AlgorithmId::Aes256 => {
                 aes::encrypt_cbc_mode(key, context, in_out)
             }
-            #[cfg(feature = "des")]
-            #[allow(deprecated)]
-            AlgorithmId::DesEde | AlgorithmId::DesEde3 => {
+            #[cfg(feature = "legacy-3des")]
+            AlgorithmId::DesEdeForLegacyUseOnly | AlgorithmId::DesEde3ForLegacyUseOnly => {
                 des::encrypt_cbc_mode(key, context, in_out)
             }
         },
@@ -913,26 +1033,27 @@ fn encrypt(
             AlgorithmId::Aes128 | AlgorithmId::Aes192 | AlgorithmId::Aes256 => {
                 aes::encrypt_ctr_mode(key, context, in_out)
             }
-            #[cfg(feature = "des")]
-            #[allow(deprecated)]
-            AlgorithmId::DesEde | AlgorithmId::DesEde3 => Err(Unspecified),
+            #[cfg(feature = "legacy-3des")]
+            AlgorithmId::DesEdeForLegacyUseOnly | AlgorithmId::DesEde3ForLegacyUseOnly => {
+                Err(Unspecified)
+            }
         },
         // TODO: Hopefully support CFB1, and CFB8
         OperatingMode::CFB128 => match algorithm.id() {
             AlgorithmId::Aes128 | AlgorithmId::Aes192 | AlgorithmId::Aes256 => {
                 aes::encrypt_cfb_mode(key, mode, context, in_out)
             }
-            #[cfg(feature = "des")]
-            #[allow(deprecated)]
-            AlgorithmId::DesEde | AlgorithmId::DesEde3 => Err(Unspecified),
+            #[cfg(feature = "legacy-3des")]
+            AlgorithmId::DesEdeForLegacyUseOnly | AlgorithmId::DesEde3ForLegacyUseOnly => {
+                Err(Unspecified)
+            }
         },
         OperatingMode::ECB => match algorithm.id() {
             AlgorithmId::Aes128 | AlgorithmId::Aes192 | AlgorithmId::Aes256 => {
                 aes::encrypt_ecb_mode(key, context, in_out)
             }
-            #[cfg(feature = "des")]
-            #[allow(deprecated)]
-            AlgorithmId::DesEde | AlgorithmId::DesEde3 => {
+            #[cfg(feature = "legacy-3des")]
+            AlgorithmId::DesEdeForLegacyUseOnly | AlgorithmId::DesEde3ForLegacyUseOnly => {
                 des::encrypt_ecb_mode(key, context, in_out)
             }
         },
@@ -960,9 +1081,8 @@ fn decrypt<'in_out>(
             AlgorithmId::Aes128 | AlgorithmId::Aes192 | AlgorithmId::Aes256 => {
                 aes::decrypt_cbc_mode(key, context, in_out)
             }
-            #[cfg(feature = "des")]
-            #[allow(deprecated)]
-            AlgorithmId::DesEde | AlgorithmId::DesEde3 => {
+            #[cfg(feature = "legacy-3des")]
+            AlgorithmId::DesEdeForLegacyUseOnly | AlgorithmId::DesEde3ForLegacyUseOnly => {
                 des::decrypt_cbc_mode(key, context, in_out)
             }
         },
@@ -970,26 +1090,27 @@ fn decrypt<'in_out>(
             AlgorithmId::Aes128 | AlgorithmId::Aes192 | AlgorithmId::Aes256 => {
                 aes::decrypt_ctr_mode(key, context, in_out)
             }
-            #[cfg(feature = "des")]
-            #[allow(deprecated)]
-            AlgorithmId::DesEde | AlgorithmId::DesEde3 => Err(Unspecified),
+            #[cfg(feature = "legacy-3des")]
+            AlgorithmId::DesEdeForLegacyUseOnly | AlgorithmId::DesEde3ForLegacyUseOnly => {
+                Err(Unspecified)
+            }
         },
         // TODO: Hopefully support CFB1, and CFB8
         OperatingMode::CFB128 => match algorithm.id() {
             AlgorithmId::Aes128 | AlgorithmId::Aes192 | AlgorithmId::Aes256 => {
                 aes::decrypt_cfb_mode(key, mode, context, in_out)
             }
-            #[cfg(feature = "des")]
-            #[allow(deprecated)]
-            AlgorithmId::DesEde | AlgorithmId::DesEde3 => Err(Unspecified),
+            #[cfg(feature = "legacy-3des")]
+            AlgorithmId::DesEdeForLegacyUseOnly | AlgorithmId::DesEde3ForLegacyUseOnly => {
+                Err(Unspecified)
+            }
         },
         OperatingMode::ECB => match algorithm.id() {
             AlgorithmId::Aes128 | AlgorithmId::Aes192 | AlgorithmId::Aes256 => {
                 aes::decrypt_ecb_mode(key, context, in_out)
             }
-            #[cfg(feature = "des")]
-            #[allow(deprecated)]
-            AlgorithmId::DesEde | AlgorithmId::DesEde3 => {
+            #[cfg(feature = "legacy-3des")]
+            AlgorithmId::DesEdeForLegacyUseOnly | AlgorithmId::DesEde3ForLegacyUseOnly => {
                 des::decrypt_ecb_mode(key, context, in_out)
             }
         },
@@ -1329,55 +1450,264 @@ mod tests {
         "f58c4c04d6e5f1ba779eabfb5f7bfbd69cfc4e967edb808d679f777bc6702c7d39f23369a9d9bacfa530e26304231461b2eb05e2c39be9fcda6c19078c6a9d1b"
     );
 
-    #[cfg(feature = "des")]
+    #[cfg(feature = "legacy-3des")]
+    #[test]
+    #[allow(deprecated)]
+    fn test_des_ede_rejects_k1_equal_k2() {
+        // SP 800-67 §3.1 requires K1 != K2 for 2-Key TDEA. If K1 == K2 then
+        // 2TDEA collapses to single-DES (56-bit effective security).
+        let weak_key = from_hex("0123456789abcdef0123456789abcdef").unwrap();
+        let result = UnboundCipherKey::new(&DES_EDE_FOR_LEGACY_USE_ONLY, &weak_key)
+            .and_then(EncryptingKey::cbc);
+        assert!(result.is_err(), "expected K1 == K2 to be rejected");
+
+        // Sanity check: differing K1 and K2 of the same length is accepted.
+        let good_key = from_hex("0123456789abcdef23456789abcdef01").unwrap();
+        UnboundCipherKey::new(&DES_EDE_FOR_LEGACY_USE_ONLY, &good_key)
+            .and_then(EncryptingKey::cbc)
+            .expect("valid 2TDEA key should be accepted");
+    }
+
+    #[cfg(feature = "legacy-3des")]
+    #[test]
+    #[allow(deprecated)]
+    fn test_des_ede_rejects_weak_subkey() {
+        // Each of DES_set_key's four weak keys must be rejected when used as
+        // either subkey of a 2TDEA key. The weak keys (with correct odd
+        // parity) are 0101..01, FEFE..FE, E0E0..E0F1F1..F1, and
+        // 1F1F..1F0E0E..0E; see openssl/des.h.
+        let weak_keys: [&str; 4] = [
+            "0101010101010101",
+            "fefefefefefefefe",
+            "e0e0e0e0f1f1f1f1",
+            "1f1f1f1f0e0e0e0e",
+        ];
+        let distinct = "23456789abcdef01";
+        for weak in &weak_keys {
+            // Weak K1, non-weak K2.
+            let key = from_hex(&format!("{}{}", weak, distinct)).unwrap();
+            assert!(
+                UnboundCipherKey::new(&DES_EDE_FOR_LEGACY_USE_ONLY, &key)
+                    .and_then(EncryptingKey::cbc)
+                    .is_err(),
+                "expected weak DES K1 = {weak} to be rejected in 2TDEA"
+            );
+            // Non-weak K1, weak K2.
+            let key = from_hex(&format!("{}{}", distinct, weak)).unwrap();
+            assert!(
+                UnboundCipherKey::new(&DES_EDE_FOR_LEGACY_USE_ONLY, &key)
+                    .and_then(EncryptingKey::cbc)
+                    .is_err(),
+                "expected weak DES K2 = {weak} to be rejected in 2TDEA"
+            );
+        }
+    }
+
+    #[cfg(feature = "legacy-3des")]
+    #[test]
+    #[allow(deprecated)]
+    fn test_des_ede3_rejects_degenerate_keys() {
+        // SP 800-67r2 Appendix A: 3TDEA requires K1, K2, and K3 to be
+        // independently chosen. We enforce that all three subkeys are
+        // pairwise distinct so the cipher cannot degenerate to single-DES
+        // (K1 == K2 or K2 == K3) or to 2TDEA (K1 == K3). Callers who want
+        // 2TDEA must use `DES_EDE_FOR_LEGACY_USE_ONLY` with a 16-byte key.
+        let k1_eq_k2 = from_hex("0123456789abcdef0123456789abcdef456789abcdef0123").unwrap();
+        assert!(
+            UnboundCipherKey::new(&DES_EDE3_FOR_LEGACY_USE_ONLY, &k1_eq_k2)
+                .and_then(EncryptingKey::cbc)
+                .is_err(),
+            "expected K1 == K2 to be rejected for 3TDEA"
+        );
+
+        let k2_eq_k3 = from_hex("0123456789abcdef23456789abcdef0123456789abcdef01").unwrap();
+        assert!(
+            UnboundCipherKey::new(&DES_EDE3_FOR_LEGACY_USE_ONLY, &k2_eq_k3)
+                .and_then(EncryptingKey::cbc)
+                .is_err(),
+            "expected K2 == K3 to be rejected for 3TDEA"
+        );
+
+        let k1_eq_k3 = from_hex("0123456789abcdef23456789abcdef010123456789abcdef").unwrap();
+        assert!(
+            UnboundCipherKey::new(&DES_EDE3_FOR_LEGACY_USE_ONLY, &k1_eq_k3)
+                .and_then(EncryptingKey::cbc)
+                .is_err(),
+            "expected K1 == K3 (2TDEA-in-3TDEA form) to be rejected for 3TDEA"
+        );
+
+        // All three distinct is accepted.
+        let good_key = from_hex("0123456789abcdef23456789abcdef01456789abcdef0123").unwrap();
+        UnboundCipherKey::new(&DES_EDE3_FOR_LEGACY_USE_ONLY, &good_key)
+            .and_then(EncryptingKey::cbc)
+            .expect("valid 3TDEA key should be accepted");
+    }
+
+    #[cfg(feature = "legacy-3des")]
+    #[test]
+    #[allow(deprecated)]
+    fn test_des_ede3_rejects_weak_subkey() {
+        // Each of `DES_set_key`'s four weak keys must be rejected when used
+        // as any subkey of a 3TDEA key. The weak keys (with correct odd
+        // parity) are 0101..01, FEFE..FE, E0E0..E0F1F1..F1, and
+        // 1F1F..1F0E0E..0E; see openssl/des.h.
+        let weak_keys: [&str; 4] = [
+            "0101010101010101",
+            "fefefefefefefefe",
+            "e0e0e0e0f1f1f1f1",
+            "1f1f1f1f0e0e0e0e",
+        ];
+        let fillers = ["23456789abcdef01", "456789abcdef0123"];
+
+        for weak in &weak_keys {
+            for position in 0..3 {
+                // Place the weak key at `position` and fill the other two
+                // slots with distinct non-weak subkeys so that the K1 != K2
+                // and K2 != K3 checks do not short-circuit the weak-key
+                // rejection we are trying to exercise.
+                let mut parts = [""; 3];
+                parts[position] = *weak;
+                parts[(position + 1) % 3] = fillers[0];
+                parts[(position + 2) % 3] = fillers[1];
+                let key = from_hex(&format!("{}{}{}", parts[0], parts[1], parts[2])).unwrap();
+                assert!(
+                    UnboundCipherKey::new(&DES_EDE3_FOR_LEGACY_USE_ONLY, &key)
+                        .and_then(EncryptingKey::cbc)
+                        .is_err(),
+                    "expected weak DES subkey {weak} at position {position} to be rejected"
+                );
+            }
+        }
+    }
+
+    #[cfg(feature = "legacy-3des")]
+    #[test]
+    #[allow(deprecated)]
+    fn test_des_rejects_unsupported_modes() {
+        // 2TDEA/3TDEA only support CBC and ECB in this crate; CTR and CFB128
+        // must be rejected at construction time rather than at encrypt time.
+        let key2 = from_hex("0123456789abcdef23456789abcdef01").unwrap();
+        assert!(
+            UnboundCipherKey::new(&DES_EDE_FOR_LEGACY_USE_ONLY, &key2)
+                .and_then(EncryptingKey::ctr)
+                .is_err(),
+            "2TDEA + CTR (encrypt) should be rejected"
+        );
+        assert!(
+            UnboundCipherKey::new(&DES_EDE_FOR_LEGACY_USE_ONLY, &key2)
+                .and_then(EncryptingKey::cfb128)
+                .is_err(),
+            "2TDEA + CFB128 (encrypt) should be rejected"
+        );
+        assert!(
+            UnboundCipherKey::new(&DES_EDE_FOR_LEGACY_USE_ONLY, &key2)
+                .and_then(DecryptingKey::ctr)
+                .is_err(),
+            "2TDEA + CTR (decrypt) should be rejected"
+        );
+        assert!(
+            UnboundCipherKey::new(&DES_EDE_FOR_LEGACY_USE_ONLY, &key2)
+                .and_then(DecryptingKey::cfb128)
+                .is_err(),
+            "2TDEA + CFB128 (decrypt) should be rejected"
+        );
+
+        let key3 = from_hex("0123456789abcdef23456789abcdef01456789abcdef0123").unwrap();
+        assert!(
+            UnboundCipherKey::new(&DES_EDE3_FOR_LEGACY_USE_ONLY, &key3)
+                .and_then(EncryptingKey::ctr)
+                .is_err(),
+            "3TDEA + CTR (encrypt) should be rejected"
+        );
+        assert!(
+            UnboundCipherKey::new(&DES_EDE3_FOR_LEGACY_USE_ONLY, &key3)
+                .and_then(EncryptingKey::cfb128)
+                .is_err(),
+            "3TDEA + CFB128 (encrypt) should be rejected"
+        );
+        assert!(
+            UnboundCipherKey::new(&DES_EDE3_FOR_LEGACY_USE_ONLY, &key3)
+                .and_then(DecryptingKey::ctr)
+                .is_err(),
+            "3TDEA + CTR (decrypt) should be rejected"
+        );
+        assert!(
+            UnboundCipherKey::new(&DES_EDE3_FOR_LEGACY_USE_ONLY, &key3)
+                .and_then(DecryptingKey::cfb128)
+                .is_err(),
+            "3TDEA + CFB128 (decrypt) should be rejected"
+        );
+    }
+
+    #[cfg(feature = "legacy-3des")]
     #[test]
     #[allow(deprecated)]
     fn test_des_ede_cbc() {
         let key = from_hex("0123456789abcdef23456789abcdef01").unwrap();
-        for i in 1..=3 {
+        for i in 0..=3 {
             let size = i * 8;
-            helper_test_cipher_n_bytes(key.as_slice(), &DES_EDE, OperatingMode::CBC, size);
+            helper_test_cipher_n_bytes(
+                key.as_slice(),
+                &DES_EDE_FOR_LEGACY_USE_ONLY,
+                OperatingMode::CBC,
+                size,
+            );
         }
     }
 
-    #[cfg(feature = "des")]
-    #[allow(deprecated)]
+    #[cfg(feature = "legacy-3des")]
     #[test]
+    #[allow(deprecated)]
     fn test_des_ede_ecb() {
         let key = from_hex("0123456789abcdef23456789abcdef01").unwrap();
-        for i in 1..=3 {
+        for i in 0..=3 {
             let size = i * 8;
-            helper_test_cipher_n_bytes(key.as_slice(), &DES_EDE, OperatingMode::ECB, size);
+            helper_test_cipher_n_bytes(
+                key.as_slice(),
+                &DES_EDE_FOR_LEGACY_USE_ONLY,
+                OperatingMode::ECB,
+                size,
+            );
         }
     }
 
-    #[cfg(feature = "des")]
+    #[cfg(feature = "legacy-3des")]
     #[test]
     #[allow(deprecated)]
     fn test_des_ede3_cbc() {
         let key = from_hex("0123456789abcdef23456789abcdef01456789abcdef0123").unwrap();
-        for i in 1..=3 {
+        for i in 0..=3 {
             let size = i * 8;
-            helper_test_cipher_n_bytes(key.as_slice(), &DES_EDE3, OperatingMode::CBC, size);
+            helper_test_cipher_n_bytes(
+                key.as_slice(),
+                &DES_EDE3_FOR_LEGACY_USE_ONLY,
+                OperatingMode::CBC,
+                size,
+            );
         }
     }
 
-    #[cfg(feature = "des")]
+    #[cfg(feature = "legacy-3des")]
     #[test]
     #[allow(deprecated)]
     fn test_des_ede3_ecb() {
         let key = from_hex("0123456789abcdef23456789abcdef01456789abcdef0123").unwrap();
-        for i in 1..=3 {
+        for i in 0..=3 {
             let size = i * 8;
-            helper_test_cipher_n_bytes(key.as_slice(), &DES_EDE3, OperatingMode::ECB, size);
+            helper_test_cipher_n_bytes(
+                key.as_slice(),
+                &DES_EDE3_FOR_LEGACY_USE_ONLY,
+                OperatingMode::ECB,
+                size,
+            );
         }
     }
 
-    #[cfg(feature = "des")]
+    #[cfg(feature = "legacy-3des")]
     macro_rules! des_cipher_kat {
         ($name:ident, $alg:expr, $mode:expr, $key:literal, $iv:literal, $plaintext:literal, $ciphertext:literal) => {
-            #[allow(deprecated)]
             #[test]
+            #[allow(deprecated)]
             fn $name() {
                 let key = from_hex($key).unwrap();
                 let input = from_hex($plaintext).unwrap();
@@ -1404,10 +1734,10 @@ mod tests {
         };
     }
 
-    #[cfg(feature = "des")]
+    #[cfg(feature = "legacy-3des")]
     des_cipher_kat!(
         test_sp800_67_des_ede_cbc,
-        &DES_EDE,
+        &DES_EDE_FOR_LEGACY_USE_ONLY,
         OperatingMode::CBC,
         "0123456789abcdef23456789abcdef01",
         "f69f2445df4f9b17",
@@ -1415,10 +1745,10 @@ mod tests {
         "7401CE1EAB6D003CAFF84BF47B36CC2154F0238F9FFECD8F6ACF118392B45581"
     );
 
-    #[cfg(feature = "des")]
+    #[cfg(feature = "legacy-3des")]
     des_cipher_kat!(
         test_sp800_67_des_ede_ecb,
-        &DES_EDE,
+        &DES_EDE_FOR_LEGACY_USE_ONLY,
         OperatingMode::ECB,
         "0123456789abcdef23456789abcdef01",
         "",
@@ -1426,10 +1756,10 @@ mod tests {
         "06EDE3D82884090AFF322C19F0518486730576972A666E58B6C88CF107340D3D"
     );
 
-    #[cfg(feature = "des")]
+    #[cfg(feature = "legacy-3des")]
     des_cipher_kat!(
         test_sp800_67_des_ede3_cbc,
-        &DES_EDE3,
+        &DES_EDE3_FOR_LEGACY_USE_ONLY,
         OperatingMode::CBC,
         "0123456789abcdef23456789abcdef01456789abcdef0123",
         "f69f2445df4f9b17",
@@ -1437,10 +1767,10 @@ mod tests {
         "2079c3d53aa763e193b79e2569ab5262516570481f25b50f73c0bda85c8e0da7"
     );
 
-    #[cfg(feature = "des")]
+    #[cfg(feature = "legacy-3des")]
     des_cipher_kat!(
         test_sp800_67_des_ede3_ecb,
-        &DES_EDE3,
+        &DES_EDE3_FOR_LEGACY_USE_ONLY,
         OperatingMode::ECB,
         "0123456789abcdef23456789abcdef01456789abcdef0123",
         "",

--- a/aws-lc-rs/src/cipher/des.rs
+++ b/aws-lc-rs/src/cipher/des.rs
@@ -5,6 +5,7 @@ use crate::aws_lc::{
     DES_cblock, DES_ecb3_encrypt, DES_ede3_cbc_encrypt, DES_key_schedule, DES_DECRYPT, DES_ENCRYPT,
 };
 use crate::error::Unspecified;
+use crate::fips::indicator_check;
 use zeroize::Zeroize;
 
 use super::{DecryptionContext, EncryptionContext, SymmetricCipherKey};
@@ -15,11 +16,15 @@ pub const DES_EDE_KEY_LEN: usize = 16;
 /// Length of a 3TDEA (DES-EDE3) key in bytes.
 pub const DES_EDE3_KEY_LEN: usize = 24;
 
-/// The number of bytes for an DES CBC initialization vector (IV)
+/// The number of bytes for a DES CBC initialization vector (IV).
 pub const DES_CBC_IV_LEN: usize = 8;
 
-pub const DES_BLOCK_LEN: usize = 8;
+pub(crate) const DES_BLOCK_LEN: usize = 8;
 
+// `#[repr(transparent)]` documents that `DesKey` has the same layout as the
+// wrapped array, which the `Drop` impl in `key.rs` relies on when it zeroizes
+// the key schedule bytes through a byte-slice view.
+#[repr(transparent)]
 pub(crate) struct DesKey(pub(super) [DES_key_schedule; 3]);
 
 pub(super) fn encrypt_cbc_mode(
@@ -80,16 +85,20 @@ pub(super) fn encrypt_ecb_mode(
     in_out: &mut [u8],
 ) -> Result<DecryptionContext, Unspecified> {
     if !matches!(context, EncryptionContext::None) {
-        return Err(Unspecified);
+        unreachable!();
     }
 
     let (SymmetricCipherKey::DesEde { key } | SymmetricCipherKey::DesEde3 { key }) = key else {
         unreachable!()
     };
 
-    for block in in_out.chunks_exact_mut(DES_BLOCK_LEN) {
+    let mut in_out_iter = in_out.chunks_exact_mut(DES_BLOCK_LEN);
+    for block in in_out_iter.by_ref() {
         des_ecb3_encrypt(&key.0[0], &key.0[1], &key.0[2], block, DES_ENCRYPT);
     }
+    // Sanity check: `encrypt` validates that `in_out.len() % block_len == 0`
+    // for ECB mode before dispatching here.
+    debug_assert!(in_out_iter.into_remainder().is_empty());
 
     Ok(context.into())
 }
@@ -100,15 +109,27 @@ pub(super) fn decrypt_ecb_mode<'in_out>(
     in_out: &'in_out mut [u8],
 ) -> Result<&'in_out mut [u8], Unspecified> {
     if !matches!(context, DecryptionContext::None) {
-        return Err(Unspecified);
+        unreachable!();
     }
 
     let (SymmetricCipherKey::DesEde { key } | SymmetricCipherKey::DesEde3 { key }) = key else {
         unreachable!()
     };
 
-    for block in in_out.chunks_exact_mut(DES_BLOCK_LEN) {
-        des_ecb3_encrypt(&key.0[0], &key.0[1], &key.0[2], block, DES_DECRYPT);
+    // The inner scope ends the mutable borrow of `in_out` held by
+    // `in_out_iter` before we return `Ok(in_out)` below. `into_remainder()`
+    // would also consume the iterator and release the borrow, but it's inside
+    // a `debug_assert!` and therefore not evaluated in release builds, so we
+    // can't rely on it for that purpose. `encrypt_ecb_mode` doesn't need this
+    // scope because it doesn't return `in_out`.
+    {
+        let mut in_out_iter = in_out.chunks_exact_mut(DES_BLOCK_LEN);
+        for block in in_out_iter.by_ref() {
+            des_ecb3_encrypt(&key.0[0], &key.0[1], &key.0[2], block, DES_DECRYPT);
+        }
+        // Sanity check: `decrypt` validates that `in_out.len() % block_len == 0`
+        // for ECB mode before dispatching here.
+        debug_assert!(in_out_iter.into_remainder().is_empty());
     }
 
     Ok(in_out)
@@ -122,7 +143,16 @@ fn des_ede_cbc_encrypt(
     in_out: &mut [u8],
     enc: i32,
 ) {
-    unsafe {
+    // The caller (`encrypt`/`decrypt` in cipher.rs) validates block alignment
+    // for CBC mode; assert here as a safety net.
+    debug_assert_eq!(in_out.len() % DES_BLOCK_LEN, 0);
+
+    // DES is not FIPS-approved; `indicator_check!` will observe that the
+    // underlying call does not increment the approved-operation counter and
+    // correctly mark the service indicator as unapproved in FIPS builds.
+    //
+    // SAFETY: `DES_ede3_cbc_encrypt` supports in-place operation (in == out).
+    indicator_check!(unsafe {
         DES_ede3_cbc_encrypt(
             in_out.as_ptr(),
             in_out.as_mut_ptr(),
@@ -133,7 +163,7 @@ fn des_ede_cbc_encrypt(
             iv.as_mut_ptr() as *mut DES_cblock,
             enc,
         );
-    }
+    });
 }
 
 fn des_ecb3_encrypt(
@@ -145,7 +175,13 @@ fn des_ecb3_encrypt(
 ) {
     let input_block = block.as_ptr() as *const DES_cblock;
     let output_block = block.as_mut_ptr() as *mut DES_cblock;
-    unsafe {
+    // DES is not FIPS-approved; `indicator_check!` will observe that the
+    // underlying call does not increment the approved-operation counter and
+    // correctly mark the service indicator as unapproved in FIPS builds.
+    //
+    // SAFETY: `input_block` and `output_block` point to the same allocation;
+    // `DES_ecb3_encrypt` supports in-place operation.
+    indicator_check!(unsafe {
         DES_ecb3_encrypt(input_block, output_block, ks1, ks2, ks3, enc);
-    }
+    });
 }

--- a/aws-lc-rs/src/cipher/des.rs
+++ b/aws-lc-rs/src/cipher/des.rs
@@ -1,0 +1,151 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR ISC
+
+use crate::aws_lc::{
+    DES_cblock, DES_ecb3_encrypt, DES_ede3_cbc_encrypt, DES_key_schedule, DES_DECRYPT, DES_ENCRYPT,
+};
+use crate::error::Unspecified;
+use zeroize::Zeroize;
+
+use super::{DecryptionContext, EncryptionContext, SymmetricCipherKey};
+
+/// Length of a 2TDEA (DES-EDE) key in bytes.
+pub const DES_EDE_KEY_LEN: usize = 16;
+
+/// Length of a 3TDEA (DES-EDE3) key in bytes.
+pub const DES_EDE3_KEY_LEN: usize = 24;
+
+/// The number of bytes for an DES CBC initialization vector (IV)
+pub const DES_CBC_IV_LEN: usize = 8;
+
+pub const DES_BLOCK_LEN: usize = 8;
+
+pub(crate) struct DesKey(pub(super) [DES_key_schedule; 3]);
+
+pub(super) fn encrypt_cbc_mode(
+    key: &SymmetricCipherKey,
+    context: EncryptionContext,
+    in_out: &mut [u8],
+) -> Result<DecryptionContext, Unspecified> {
+    let (SymmetricCipherKey::DesEde { key } | SymmetricCipherKey::DesEde3 { key }) = key else {
+        unreachable!()
+    };
+
+    let iv_bytes: &[u8] = (&context).try_into()?;
+    let mut iv = [0u8; DES_CBC_IV_LEN];
+    iv.copy_from_slice(iv_bytes);
+
+    des_ede_cbc_encrypt(
+        &key.0[0],
+        &key.0[1],
+        &key.0[2],
+        &mut iv,
+        in_out,
+        DES_ENCRYPT,
+    );
+
+    iv.zeroize();
+    Ok(context.into())
+}
+
+pub(super) fn decrypt_cbc_mode<'in_out>(
+    key: &SymmetricCipherKey,
+    context: DecryptionContext,
+    in_out: &'in_out mut [u8],
+) -> Result<&'in_out mut [u8], Unspecified> {
+    let (SymmetricCipherKey::DesEde { key } | SymmetricCipherKey::DesEde3 { key }) = key else {
+        unreachable!()
+    };
+
+    let iv_bytes: &[u8] = (&context).try_into()?;
+    let mut iv = [0u8; DES_CBC_IV_LEN];
+    iv.copy_from_slice(iv_bytes);
+
+    des_ede_cbc_encrypt(
+        &key.0[0],
+        &key.0[1],
+        &key.0[2],
+        &mut iv,
+        in_out,
+        DES_DECRYPT,
+    );
+
+    iv.zeroize();
+    Ok(in_out)
+}
+
+pub(super) fn encrypt_ecb_mode(
+    key: &SymmetricCipherKey,
+    context: EncryptionContext,
+    in_out: &mut [u8],
+) -> Result<DecryptionContext, Unspecified> {
+    if !matches!(context, EncryptionContext::None) {
+        return Err(Unspecified);
+    }
+
+    let (SymmetricCipherKey::DesEde { key } | SymmetricCipherKey::DesEde3 { key }) = key else {
+        unreachable!()
+    };
+
+    for block in in_out.chunks_exact_mut(DES_BLOCK_LEN) {
+        des_ecb3_encrypt(&key.0[0], &key.0[1], &key.0[2], block, DES_ENCRYPT);
+    }
+
+    Ok(context.into())
+}
+
+pub(super) fn decrypt_ecb_mode<'in_out>(
+    key: &SymmetricCipherKey,
+    context: DecryptionContext,
+    in_out: &'in_out mut [u8],
+) -> Result<&'in_out mut [u8], Unspecified> {
+    if !matches!(context, DecryptionContext::None) {
+        return Err(Unspecified);
+    }
+
+    let (SymmetricCipherKey::DesEde { key } | SymmetricCipherKey::DesEde3 { key }) = key else {
+        unreachable!()
+    };
+
+    for block in in_out.chunks_exact_mut(DES_BLOCK_LEN) {
+        des_ecb3_encrypt(&key.0[0], &key.0[1], &key.0[2], block, DES_DECRYPT);
+    }
+
+    Ok(in_out)
+}
+
+fn des_ede_cbc_encrypt(
+    ks1: &DES_key_schedule,
+    ks2: &DES_key_schedule,
+    ks3: &DES_key_schedule,
+    iv: &mut [u8; DES_CBC_IV_LEN],
+    in_out: &mut [u8],
+    enc: i32,
+) {
+    unsafe {
+        DES_ede3_cbc_encrypt(
+            in_out.as_ptr(),
+            in_out.as_mut_ptr(),
+            in_out.len(),
+            ks1,
+            ks2,
+            ks3,
+            iv.as_mut_ptr() as *mut DES_cblock,
+            enc,
+        );
+    }
+}
+
+fn des_ecb3_encrypt(
+    ks1: &DES_key_schedule,
+    ks2: &DES_key_schedule,
+    ks3: &DES_key_schedule,
+    block: &mut [u8],
+    enc: i32,
+) {
+    let input_block = block.as_ptr() as *const DES_cblock;
+    let output_block = block.as_mut_ptr() as *mut DES_cblock;
+    unsafe {
+        DES_ecb3_encrypt(input_block, output_block, ks1, ks2, ks3, enc);
+    }
+}

--- a/aws-lc-rs/src/cipher/key.rs
+++ b/aws-lc-rs/src/cipher/key.rs
@@ -2,8 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0 OR ISC
 
 use crate::aws_lc::{AES_set_decrypt_key, AES_set_encrypt_key, AES_KEY};
+#[cfg(feature = "des")]
+use crate::aws_lc::{DES_cblock, DES_key_schedule, DES_set_key};
 use crate::cipher::block::Block;
 use crate::cipher::chacha::ChaCha20Key;
+#[cfg(feature = "des")]
+use crate::cipher::des::{DesKey, DES_EDE3_KEY_LEN, DES_EDE_KEY_LEN};
 use crate::cipher::{AES_128_KEY_LEN, AES_192_KEY_LEN, AES_256_KEY_LEN};
 use crate::error::Unspecified;
 use core::mem::{size_of, MaybeUninit};
@@ -14,10 +18,29 @@ use std::os::raw::c_uint;
 use zeroize::Zeroize;
 
 pub(crate) enum SymmetricCipherKey {
-    Aes128 { enc_key: AES_KEY, dec_key: AES_KEY },
-    Aes192 { enc_key: AES_KEY, dec_key: AES_KEY },
-    Aes256 { enc_key: AES_KEY, dec_key: AES_KEY },
-    ChaCha20 { raw_key: ChaCha20Key },
+    Aes128 {
+        enc_key: AES_KEY,
+        dec_key: AES_KEY,
+    },
+    Aes192 {
+        enc_key: AES_KEY,
+        dec_key: AES_KEY,
+    },
+    Aes256 {
+        enc_key: AES_KEY,
+        dec_key: AES_KEY,
+    },
+    ChaCha20 {
+        raw_key: ChaCha20Key,
+    },
+    #[cfg(feature = "des")]
+    DesEde {
+        key: DesKey,
+    },
+    #[cfg(feature = "des")]
+    DesEde3 {
+        key: DesKey,
+    },
 }
 
 unsafe impl Send for SymmetricCipherKey {}
@@ -44,6 +67,14 @@ impl Drop for SymmetricCipherKey {
                 dec_bytes.zeroize();
             },
             SymmetricCipherKey::ChaCha20 { .. } => {}
+            #[cfg(feature = "des")]
+            SymmetricCipherKey::DesEde { key } | SymmetricCipherKey::DesEde3 { key } => unsafe {
+                let key_bytes: &mut [u8; size_of::<DesKey>()] = (key as *mut DesKey)
+                    .cast::<[u8; size_of::<DesKey>()]>()
+                    .as_mut()
+                    .unwrap();
+                key_bytes.zeroize();
+            },
         }
     }
 }
@@ -113,6 +144,92 @@ impl SymmetricCipherKey {
         }
     }
 
+    #[cfg(feature = "des")]
+    pub(crate) fn des_ede(key_bytes: &[u8]) -> Result<Self, Unspecified> {
+        if key_bytes.len() != DES_EDE_KEY_LEN {
+            return Err(Unspecified);
+        }
+        let mut ks0 = MaybeUninit::<DES_key_schedule>::uninit();
+        let mut ks1 = MaybeUninit::<DES_key_schedule>::uninit();
+        let mut ks2 = MaybeUninit::<DES_key_schedule>::uninit();
+        if -2
+            == unsafe {
+                DES_set_key(
+                    key_bytes[0..8].as_ptr() as *const DES_cblock,
+                    ks0.as_mut_ptr(),
+                )
+            }
+        {
+            return Err(Unspecified);
+        }
+        if -2
+            == unsafe {
+                DES_set_key(
+                    key_bytes[8..16].as_ptr() as *const DES_cblock,
+                    ks1.as_mut_ptr(),
+                )
+            }
+        {
+            return Err(Unspecified);
+        }
+        if -2
+            == unsafe {
+                DES_set_key(
+                    key_bytes[0..8].as_ptr() as *const DES_cblock,
+                    ks2.as_mut_ptr(),
+                )
+            }
+        {
+            return Err(Unspecified);
+        }
+        Ok(SymmetricCipherKey::DesEde {
+            key: DesKey(unsafe { [ks0.assume_init(), ks1.assume_init(), ks2.assume_init()] }),
+        })
+    }
+
+    #[cfg(feature = "des")]
+    pub(crate) fn des_ede3(key_bytes: &[u8]) -> Result<Self, Unspecified> {
+        if key_bytes.len() != DES_EDE3_KEY_LEN {
+            return Err(Unspecified);
+        }
+        let mut ks0 = MaybeUninit::<DES_key_schedule>::uninit();
+        let mut ks1 = MaybeUninit::<DES_key_schedule>::uninit();
+        let mut ks2 = MaybeUninit::<DES_key_schedule>::uninit();
+        if -2
+            == unsafe {
+                DES_set_key(
+                    key_bytes[0..8].as_ptr() as *const DES_cblock,
+                    ks0.as_mut_ptr(),
+                )
+            }
+        {
+            return Err(Unspecified);
+        }
+        if -2
+            == unsafe {
+                DES_set_key(
+                    key_bytes[8..16].as_ptr() as *const DES_cblock,
+                    ks1.as_mut_ptr(),
+                )
+            }
+        {
+            return Err(Unspecified);
+        }
+        if -2
+            == unsafe {
+                DES_set_key(
+                    key_bytes[16..24].as_ptr() as *const DES_cblock,
+                    ks2.as_mut_ptr(),
+                )
+            }
+        {
+            return Err(Unspecified);
+        }
+        Ok(SymmetricCipherKey::DesEde3 {
+            key: DesKey(unsafe { [ks0.assume_init(), ks1.assume_init(), ks2.assume_init()] }),
+        })
+    }
+
     #[allow(dead_code)]
     #[inline]
     pub(crate) fn encrypt_block(&self, block: Block) -> Block {
@@ -122,7 +239,13 @@ impl SymmetricCipherKey {
             | SymmetricCipherKey::Aes256 { enc_key, .. } => {
                 super::aes::encrypt_block(enc_key, block)
             }
-            SymmetricCipherKey::ChaCha20 { .. } => panic!("Unsupported algorithm!"),
+            SymmetricCipherKey::ChaCha20 { .. } => {
+                panic!("Unsupported algorithm!")
+            }
+            #[cfg(feature = "des")]
+            SymmetricCipherKey::DesEde { .. } | SymmetricCipherKey::DesEde3 { .. } => {
+                panic!("Unsupported algorithm!")
+            }
         }
     }
 }

--- a/aws-lc-rs/src/cipher/key.rs
+++ b/aws-lc-rs/src/cipher/key.rs
@@ -2,14 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0 OR ISC
 
 use crate::aws_lc::{AES_set_decrypt_key, AES_set_encrypt_key, AES_KEY};
-#[cfg(feature = "des")]
+#[cfg(feature = "legacy-3des")]
 use crate::aws_lc::{DES_cblock, DES_key_schedule, DES_set_key};
 use crate::cipher::block::Block;
 use crate::cipher::chacha::ChaCha20Key;
-#[cfg(feature = "des")]
+#[cfg(feature = "legacy-3des")]
 use crate::cipher::des::{DesKey, DES_EDE3_KEY_LEN, DES_EDE_KEY_LEN};
 use crate::cipher::{AES_128_KEY_LEN, AES_192_KEY_LEN, AES_256_KEY_LEN};
-use crate::error::Unspecified;
+use crate::error::{KeyRejected, Unspecified};
 use core::mem::{size_of, MaybeUninit};
 use core::ptr::copy_nonoverlapping;
 // TODO: Uncomment when MSRV >= 1.64
@@ -33,11 +33,11 @@ pub(crate) enum SymmetricCipherKey {
     ChaCha20 {
         raw_key: ChaCha20Key,
     },
-    #[cfg(feature = "des")]
+    #[cfg(feature = "legacy-3des")]
     DesEde {
         key: DesKey,
     },
-    #[cfg(feature = "des")]
+    #[cfg(feature = "legacy-3des")]
     DesEde3 {
         key: DesKey,
     },
@@ -67,7 +67,7 @@ impl Drop for SymmetricCipherKey {
                 dec_bytes.zeroize();
             },
             SymmetricCipherKey::ChaCha20 { .. } => {}
-            #[cfg(feature = "des")]
+            #[cfg(feature = "legacy-3des")]
             SymmetricCipherKey::DesEde { key } | SymmetricCipherKey::DesEde3 { key } => unsafe {
                 let key_bytes: &mut [u8; size_of::<DesKey>()] = (key as *mut DesKey)
                     .cast::<[u8; size_of::<DesKey>()]>()
@@ -107,33 +107,33 @@ impl SymmetricCipherKey {
         unsafe { Ok((enc_key.assume_init(), dec_key.assume_init())) }
     }
 
-    pub(crate) fn aes128(key_bytes: &[u8]) -> Result<Self, Unspecified> {
+    pub(crate) fn aes128(key_bytes: &[u8]) -> Result<Self, KeyRejected> {
         if key_bytes.len() != AES_128_KEY_LEN {
-            return Err(Unspecified);
+            return Err(KeyRejected::unspecified());
         }
         let (enc_key, dec_key) = SymmetricCipherKey::aes(key_bytes)?;
         Ok(SymmetricCipherKey::Aes128 { enc_key, dec_key })
     }
 
-    pub(crate) fn aes192(key_bytes: &[u8]) -> Result<Self, Unspecified> {
+    pub(crate) fn aes192(key_bytes: &[u8]) -> Result<Self, KeyRejected> {
         if key_bytes.len() != AES_192_KEY_LEN {
-            return Err(Unspecified);
+            return Err(KeyRejected::unspecified());
         }
         let (enc_key, dec_key) = SymmetricCipherKey::aes(key_bytes)?;
         Ok(SymmetricCipherKey::Aes192 { enc_key, dec_key })
     }
 
-    pub(crate) fn aes256(key_bytes: &[u8]) -> Result<Self, Unspecified> {
+    pub(crate) fn aes256(key_bytes: &[u8]) -> Result<Self, KeyRejected> {
         if key_bytes.len() != AES_256_KEY_LEN {
-            return Err(Unspecified);
+            return Err(KeyRejected::unspecified());
         }
         let (enc_key, dec_key) = SymmetricCipherKey::aes(key_bytes)?;
         Ok(SymmetricCipherKey::Aes256 { enc_key, dec_key })
     }
 
-    pub(crate) fn chacha20(key_bytes: &[u8]) -> Result<Self, Unspecified> {
+    pub(crate) fn chacha20(key_bytes: &[u8]) -> Result<Self, KeyRejected> {
         if key_bytes.len() != 32 {
-            return Err(Unspecified);
+            return Err(KeyRejected::unspecified());
         }
         let mut kb = MaybeUninit::<[u8; 32]>::uninit();
         unsafe {
@@ -144,89 +144,104 @@ impl SymmetricCipherKey {
         }
     }
 
-    #[cfg(feature = "des")]
-    pub(crate) fn des_ede(key_bytes: &[u8]) -> Result<Self, Unspecified> {
+    /// Validates 2TDEA key material and computes the three DES key schedules.
+    ///
+    /// Returns the schedules as `[ks1, ks2, ks1]` (K3 = K1 for 2TDEA).
+    /// This is the shared validation/preparation step used by both
+    /// [`SymmetricCipherKey::des_ede`] and
+    /// [`UnboundCipherKey::validate_key_material`].
+    #[cfg(feature = "legacy-3des")]
+    pub(crate) fn prepare_des_ede(key_bytes: &[u8]) -> Result<[DES_key_schedule; 3], KeyRejected> {
         if key_bytes.len() != DES_EDE_KEY_LEN {
-            return Err(Unspecified);
+            return Err(KeyRejected::unspecified());
         }
-        let mut ks0 = MaybeUninit::<DES_key_schedule>::uninit();
-        let mut ks1 = MaybeUninit::<DES_key_schedule>::uninit();
-        let mut ks2 = MaybeUninit::<DES_key_schedule>::uninit();
-        if -2
-            == unsafe {
-                DES_set_key(
-                    key_bytes[0..8].as_ptr() as *const DES_cblock,
-                    ks0.as_mut_ptr(),
-                )
-            }
-        {
-            return Err(Unspecified);
+        // `as_chunks` is only stable since Rust 1.88.0, so use explicit slicing
+        // instead to stay within the crate's MSRV.
+        let first_key: &[u8; 8] = key_bytes[0..8]
+            .try_into()
+            .map_err(|_| KeyRejected::unspecified())?;
+        let second_key: &[u8; 8] = key_bytes[8..16]
+            .try_into()
+            .map_err(|_| KeyRejected::unspecified())?;
+
+        // SP 800-67 §3.1 requires K1 != K2 for 2-Key TDEA; if they are equal
+        // the cipher degenerates to single-DES (56-bit effective security).
+        if first_key == second_key {
+            return Err(KeyRejected::inconsistent_components());
         }
-        if -2
-            == unsafe {
-                DES_set_key(
-                    key_bytes[8..16].as_ptr() as *const DES_cblock,
-                    ks1.as_mut_ptr(),
-                )
-            }
-        {
-            return Err(Unspecified);
-        }
-        if -2
-            == unsafe {
-                DES_set_key(
-                    key_bytes[0..8].as_ptr() as *const DES_cblock,
-                    ks2.as_mut_ptr(),
-                )
-            }
-        {
-            return Err(Unspecified);
-        }
+
+        // 2TDEA is defined as E_K1(D_K2(E_K1(.))), so K3 is always a copy of
+        // K1. `DES_key_schedule` is `Copy`, so we only need to run the key
+        // schedule for K1 once.
+        let ks1 = Self::des_set_key(first_key)?;
+        let ks2 = Self::des_set_key(second_key)?;
+        Ok([ks1, ks2, ks1])
+    }
+
+    #[cfg(feature = "legacy-3des")]
+    pub(crate) fn des_ede(key_bytes: &[u8]) -> Result<Self, KeyRejected> {
         Ok(SymmetricCipherKey::DesEde {
-            key: DesKey(unsafe { [ks0.assume_init(), ks1.assume_init(), ks2.assume_init()] }),
+            key: DesKey(Self::prepare_des_ede(key_bytes)?),
         })
     }
 
-    #[cfg(feature = "des")]
-    pub(crate) fn des_ede3(key_bytes: &[u8]) -> Result<Self, Unspecified> {
+    #[cfg(feature = "legacy-3des")]
+    fn des_set_key(key_bytes: &[u8; 8]) -> Result<DES_key_schedule, KeyRejected> {
+        let mut ks = MaybeUninit::<DES_key_schedule>::uninit();
+        // DES_set_key return values (see openssl/des.h):
+        //   0  => key is not weak and has odd parity (preferred)
+        //  -1  => key parity is not odd (schedule is still valid; most callers
+        //         do not maintain DES parity bits, so we accept this)
+        //  -2  => key is a weak DES key; reject it
+        // Any other non-zero value is treated as a failure.
+        match unsafe { DES_set_key(key_bytes.as_ptr() as *const DES_cblock, ks.as_mut_ptr()) } {
+            0 | -1 => Ok(unsafe { ks.assume_init() }),
+            _ => Err(KeyRejected::unspecified()),
+        }
+    }
+
+    /// Validates 3TDEA key material and computes the three DES key schedules.
+    ///
+    /// This is the shared validation/preparation step used by both
+    /// [`SymmetricCipherKey::des_ede3`] and
+    /// [`UnboundCipherKey::validate_key_material`].
+    #[cfg(feature = "legacy-3des")]
+    pub(crate) fn prepare_des_ede3(key_bytes: &[u8]) -> Result<[DES_key_schedule; 3], KeyRejected> {
         if key_bytes.len() != DES_EDE3_KEY_LEN {
-            return Err(Unspecified);
+            return Err(KeyRejected::unspecified());
         }
-        let mut ks0 = MaybeUninit::<DES_key_schedule>::uninit();
-        let mut ks1 = MaybeUninit::<DES_key_schedule>::uninit();
-        let mut ks2 = MaybeUninit::<DES_key_schedule>::uninit();
-        if -2
-            == unsafe {
-                DES_set_key(
-                    key_bytes[0..8].as_ptr() as *const DES_cblock,
-                    ks0.as_mut_ptr(),
-                )
-            }
-        {
-            return Err(Unspecified);
+        // `as_chunks` is only stable since Rust 1.88.0, so use explicit slicing
+        // instead to stay within the crate's MSRV.
+        let first_key: &[u8; 8] = key_bytes[0..8]
+            .try_into()
+            .map_err(|_| KeyRejected::unspecified())?;
+        let second_key: &[u8; 8] = key_bytes[8..16]
+            .try_into()
+            .map_err(|_| KeyRejected::unspecified())?;
+        let third_key: &[u8; 8] = key_bytes[16..24]
+            .try_into()
+            .map_err(|_| KeyRejected::unspecified())?;
+
+        // SP 800-67r2 Appendix A: for 3-Key TDEA, K1, K2 and K3 should be
+        // independently chosen. We enforce that all three subkeys are
+        // distinct. Callers who want the `K1 ‖ K2 ‖ K1` (2TDEA) form must
+        // use `DES_EDE_FOR_LEGACY_USE_ONLY` with a 16-byte key instead of
+        // encoding 2TDEA as a 24-byte 3TDEA key.
+        if first_key == second_key || second_key == third_key || first_key == third_key {
+            return Err(KeyRejected::inconsistent_components());
         }
-        if -2
-            == unsafe {
-                DES_set_key(
-                    key_bytes[8..16].as_ptr() as *const DES_cblock,
-                    ks1.as_mut_ptr(),
-                )
-            }
-        {
-            return Err(Unspecified);
-        }
-        if -2
-            == unsafe {
-                DES_set_key(
-                    key_bytes[16..24].as_ptr() as *const DES_cblock,
-                    ks2.as_mut_ptr(),
-                )
-            }
-        {
-            return Err(Unspecified);
-        }
+
+        Ok([
+            Self::des_set_key(first_key)?,
+            Self::des_set_key(second_key)?,
+            Self::des_set_key(third_key)?,
+        ])
+    }
+
+    #[cfg(feature = "legacy-3des")]
+    pub(crate) fn des_ede3(key_bytes: &[u8]) -> Result<Self, KeyRejected> {
         Ok(SymmetricCipherKey::DesEde3 {
-            key: DesKey(unsafe { [ks0.assume_init(), ks1.assume_init(), ks2.assume_init()] }),
+            key: DesKey(Self::prepare_des_ede3(key_bytes)?),
         })
     }
 
@@ -242,7 +257,7 @@ impl SymmetricCipherKey {
             SymmetricCipherKey::ChaCha20 { .. } => {
                 panic!("Unsupported algorithm!")
             }
-            #[cfg(feature = "des")]
+            #[cfg(feature = "legacy-3des")]
             SymmetricCipherKey::DesEde { .. } | SymmetricCipherKey::DesEde3 { .. } => {
                 panic!("Unsupported algorithm!")
             }

--- a/aws-lc-rs/src/cipher/padded.rs
+++ b/aws-lc-rs/src/cipher/padded.rs
@@ -114,13 +114,15 @@ impl PaddedBlockEncryptingKey {
         Self::new(key, OperatingMode::ECB, PaddingStrategy::PKCS7)
     }
 
-    #[allow(clippy::unnecessary_wraps)]
     fn new(
         key: UnboundCipherKey,
         mode: OperatingMode,
         padding: PaddingStrategy,
     ) -> Result<PaddedBlockEncryptingKey, Unspecified> {
         let algorithm = key.algorithm();
+        if !algorithm.supports_mode(mode) {
+            return Err(Unspecified);
+        }
         let key = key.try_into()?;
         Ok(Self {
             algorithm,
@@ -255,13 +257,15 @@ impl PaddedBlockDecryptingKey {
         Self::new(key, OperatingMode::ECB, PaddingStrategy::PKCS7)
     }
 
-    #[allow(clippy::unnecessary_wraps)]
     fn new(
         key: UnboundCipherKey,
         mode: OperatingMode,
         padding: PaddingStrategy,
     ) -> Result<PaddedBlockDecryptingKey, Unspecified> {
         let algorithm = key.algorithm();
+        if !algorithm.supports_mode(mode) {
+            return Err(Unspecified);
+        }
         let key = key.try_into()?;
         Ok(PaddedBlockDecryptingKey {
             algorithm,

--- a/aws-lc-rs/src/cipher/streaming.rs
+++ b/aws-lc-rs/src/cipher/streaming.rs
@@ -125,6 +125,14 @@ impl StreamingEncryptingKey {
         context: EncryptionContext,
     ) -> Result<Self, Unspecified> {
         let algorithm = key.algorithm();
+        if !algorithm.supports_mode(mode) {
+            return Err(Unspecified);
+        }
+        // The streaming path passes raw key bytes to the EVP API rather than
+        // going through `SymmetricCipherKey` construction.  Validate
+        // algorithm-specific key constraints (e.g. DES weak-key / K1!=K2
+        // checks) that would otherwise be missed.
+        key.validate_key_material()?;
         let mut cipher_ctx = LcPtr::new(unsafe { EVP_CIPHER_CTX_new() })?;
         let cipher = mode.evp_cipher(key.algorithm);
         let key_bytes = key.key_bytes.as_ref();
@@ -144,7 +152,7 @@ impl StreamingEncryptingKey {
                 );
                 evp_encrypt_init(&mut cipher_ctx, &cipher, key_bytes, Some(iv))?;
             }
-            #[cfg(feature = "des")]
+            #[cfg(feature = "legacy-3des")]
             ctx @ EncryptionContext::Iv64(..) => {
                 let iv = <&[u8]>::try_from(ctx)?;
                 debug_assert_eq!(
@@ -420,8 +428,13 @@ impl StreamingDecryptingKey {
         mode: OperatingMode,
         context: DecryptionContext,
     ) -> Result<Self, Unspecified> {
-        let mut cipher_ctx = LcPtr::new(unsafe { EVP_CIPHER_CTX_new() })?;
         let algorithm = key.algorithm();
+        if !algorithm.supports_mode(mode) {
+            return Err(Unspecified);
+        }
+        // See comment in `StreamingEncryptingKey::new`.
+        key.validate_key_material()?;
+        let mut cipher_ctx = LcPtr::new(unsafe { EVP_CIPHER_CTX_new() })?;
         let cipher = mode.evp_cipher(key.algorithm);
         let key_bytes = key.key_bytes.as_ref();
         if key_bytes.len()
@@ -440,7 +453,7 @@ impl StreamingDecryptingKey {
                 );
                 evp_decrypt_init(&mut cipher_ctx, &cipher, key_bytes, Some(iv))?;
             }
-            #[cfg(feature = "des")]
+            #[cfg(feature = "legacy-3des")]
             ctx @ DecryptionContext::Iv64(..) => {
                 let iv = <&[u8]>::try_from(ctx)?;
                 debug_assert_eq!(

--- a/aws-lc-rs/src/cipher/streaming.rs
+++ b/aws-lc-rs/src/cipher/streaming.rs
@@ -144,6 +144,16 @@ impl StreamingEncryptingKey {
                 );
                 evp_encrypt_init(&mut cipher_ctx, &cipher, key_bytes, Some(iv))?;
             }
+            #[cfg(feature = "des")]
+            ctx @ EncryptionContext::Iv64(..) => {
+                let iv = <&[u8]>::try_from(ctx)?;
+                debug_assert_eq!(
+                    iv.len(),
+                    <usize>::try_from(unsafe { EVP_CIPHER_iv_length(cipher.as_const_ptr()) })
+                        .unwrap()
+                );
+                evp_encrypt_init(&mut cipher_ctx, &cipher, key_bytes, Some(iv))?;
+            }
             EncryptionContext::None => {
                 evp_encrypt_init(&mut cipher_ctx, &cipher, key_bytes, None)?;
             }
@@ -422,6 +432,16 @@ impl StreamingDecryptingKey {
 
         match &context {
             ctx @ DecryptionContext::Iv128(..) => {
+                let iv = <&[u8]>::try_from(ctx)?;
+                debug_assert_eq!(
+                    iv.len(),
+                    <usize>::try_from(unsafe { EVP_CIPHER_iv_length(cipher.as_const_ptr()) })
+                        .unwrap()
+                );
+                evp_decrypt_init(&mut cipher_ctx, &cipher, key_bytes, Some(iv))?;
+            }
+            #[cfg(feature = "des")]
+            ctx @ DecryptionContext::Iv64(..) => {
                 let iv = <&[u8]>::try_from(ctx)?;
                 debug_assert_eq!(
                     iv.len(),

--- a/aws-lc-rs/src/iv.rs
+++ b/aws-lc-rs/src/iv.rs
@@ -10,6 +10,11 @@ use crate::error::Unspecified;
 use crate::rand;
 use zeroize::Zeroize;
 
+#[cfg(feature = "des")]
+#[deprecated]
+/// Length of a 64-bit IV in bytes (used by DES/3DES).
+pub const IV_LEN_64_BIT: usize = 8;
+
 /// Length of a 128-bit IV in bytes.
 pub const IV_LEN_128_BIT: usize = 16;
 

--- a/aws-lc-rs/src/iv.rs
+++ b/aws-lc-rs/src/iv.rs
@@ -10,10 +10,9 @@ use crate::error::Unspecified;
 use crate::rand;
 use zeroize::Zeroize;
 
-#[cfg(feature = "des")]
-#[deprecated]
 /// Length of a 64-bit IV in bytes (used by DES/3DES).
-pub const IV_LEN_64_BIT: usize = 8;
+#[cfg(feature = "legacy-3des")]
+pub(crate) const IV_LEN_64_BIT: usize = 8;
 
 /// Length of a 128-bit IV in bytes.
 pub const IV_LEN_128_BIT: usize = 16;

--- a/aws-lc-rs/tests/cipher_test.rs
+++ b/aws-lc-rs/tests/cipher_test.rs
@@ -6,9 +6,9 @@ use aws_lc_rs::cipher::{
     PaddedBlockDecryptingKey, PaddedBlockEncryptingKey, StreamingDecryptingKey,
     StreamingEncryptingKey, UnboundCipherKey, AES_128, AES_192, AES_256,
 };
-#[cfg(feature = "des")]
+#[cfg(feature = "legacy-3des")]
 #[allow(deprecated)]
-use aws_lc_rs::cipher::{DES_EDE, DES_EDE3};
+use aws_lc_rs::cipher::{DES_EDE3_FOR_LEGACY_USE_ONLY, DES_EDE_FOR_LEGACY_USE_ONLY};
 use aws_lc_rs::iv::{FixedLength, IV_LEN_128_BIT};
 use aws_lc_rs::test;
 use aws_lc_rs::test::from_hex;
@@ -1114,12 +1114,12 @@ unpadded_cipher_kat!(
     "00112233445566778899aabbccddee"
 );
 
-#[cfg(feature = "des")]
+#[cfg(feature = "legacy-3des")]
 macro_rules! des_streaming_cipher_kat {
     ($name:ident, $alg:expr, $mode:expr, ecb_pkcs7, $key:literal, $plaintext:literal, $ciphertext:literal, $from_step:literal, $to_step:literal) => {
         paste! {
-        #[allow(deprecated)]
         #[test]
+        #[allow(deprecated)]
         fn [<$name _streaming>]() {
             let key = from_hex($key).unwrap();
             let input = from_hex($plaintext).unwrap();
@@ -1146,8 +1146,8 @@ macro_rules! des_streaming_cipher_kat {
 
     ($name:ident, $alg:expr, $mode:expr, $constructor:ident, $key:literal, $iv:literal, $plaintext:literal, $ciphertext:literal, $from_step:literal, $to_step:literal) => {
         paste! {
-        #[allow(deprecated)]
         #[test]
+        #[allow(deprecated)]
         fn [<$name _streaming>]() {
             let key = from_hex($key).unwrap();
             let input = from_hex($plaintext).unwrap();
@@ -1177,12 +1177,12 @@ macro_rules! des_streaming_cipher_kat {
     };
 }
 
-#[cfg(feature = "des")]
+#[cfg(feature = "legacy-3des")]
 macro_rules! des_streaming_cipher_rt {
     ($name:ident, $alg:expr, $mode:expr, $constructor:ident, $key:literal, $plaintext:literal, $from_step:literal, $to_step:literal) => {
         paste! {
-        #[allow(deprecated)]
         #[test]
+        #[allow(deprecated)]
         fn [<$name _streaming>]() {
             let key = from_hex($key).unwrap();
             let input = from_hex($plaintext).unwrap();
@@ -1205,11 +1205,11 @@ macro_rules! des_streaming_cipher_rt {
     };
 }
 
-#[cfg(feature = "des")]
+#[cfg(feature = "legacy-3des")]
 macro_rules! des_cipher_kat {
     ($name:ident, $alg:expr, $mode:expr, $constructor:ident, $key:literal, $iv:literal, $plaintext:literal, $ciphertext:literal) => {
-        #[allow(deprecated)]
         #[test]
+        #[allow(deprecated)]
         fn $name() {
             let key = from_hex($key).unwrap();
             let input = from_hex($plaintext).unwrap();
@@ -1242,8 +1242,8 @@ macro_rules! des_cipher_kat {
     };
 
     ($name:ident, $alg:expr, $mode:expr, $constructor:ident, $key:literal, $iv:literal, $plaintext:literal) => {
-        #[allow(deprecated)]
         #[test]
+        #[allow(deprecated)]
         fn $name() {
             let key = from_hex($key).unwrap();
             let input = from_hex($plaintext).unwrap();
@@ -1267,11 +1267,11 @@ macro_rules! des_cipher_kat {
     };
 }
 
-#[cfg(feature = "des")]
+#[cfg(feature = "legacy-3des")]
 macro_rules! des_padded_cipher_kat {
     ($name:ident, $alg:expr, $mode:expr, ecb_pkcs7, $key:literal, $iv:literal, $plaintext:literal, $ciphertext:literal) => {
-        #[allow(deprecated)]
         #[test]
+        #[allow(deprecated)]
         fn $name() {
             let key = from_hex($key).unwrap();
             let input = from_hex($plaintext).unwrap();
@@ -1309,8 +1309,8 @@ macro_rules! des_padded_cipher_kat {
     };
 
     ($name:ident, $alg:expr, $mode:expr, $constructor:ident, $key:literal, $iv:literal, $plaintext:literal, $ciphertext:literal) => {
-        #[allow(deprecated)]
         #[test]
+        #[allow(deprecated)]
         fn $name() {
             let key = from_hex($key).unwrap();
             let input = from_hex($plaintext).unwrap();
@@ -1356,11 +1356,11 @@ macro_rules! des_padded_cipher_kat {
     };
 }
 
-#[cfg(feature = "des")]
+#[cfg(feature = "legacy-3des")]
 macro_rules! des_cipher_rt {
     ($name:ident, $alg:expr, $mode:expr, $constructor:ident, $key:literal, $plaintext:literal) => {
-        #[allow(deprecated)]
         #[test]
+        #[allow(deprecated)]
         fn $name() {
             let key = from_hex($key).unwrap();
             let input = from_hex($plaintext).unwrap();
@@ -1383,11 +1383,11 @@ macro_rules! des_cipher_rt {
     };
 }
 
-#[cfg(feature = "des")]
+#[cfg(feature = "legacy-3des")]
 macro_rules! des_padded_cipher_rt {
     ($name:ident, $alg:expr, $mode:expr, $constructor:ident, $key:literal, $plaintext:literal) => {
-        #[allow(deprecated)]
         #[test]
+        #[allow(deprecated)]
         fn $name() {
             let key = from_hex($key).unwrap();
             let input = from_hex($plaintext).unwrap();
@@ -1411,10 +1411,10 @@ macro_rules! des_padded_cipher_rt {
     };
 }
 
-#[cfg(feature = "des")]
+#[cfg(feature = "legacy-3des")]
 des_cipher_kat!(
     test_kat_des_ede_cbc_32_bytes,
-    &DES_EDE,
+    &DES_EDE_FOR_LEGACY_USE_ONLY,
     OperatingMode::CBC,
     cbc,
     "0123456789abcdef23456789abcdef01",
@@ -1423,10 +1423,10 @@ des_cipher_kat!(
     "7401ce1eab6d003caff84bf47b36cc2154f0238f9ffecd8f6acf118392b45581"
 );
 
-#[cfg(feature = "des")]
+#[cfg(feature = "legacy-3des")]
 des_cipher_kat!(
     test_kat_des_ede3_cbc_32_bytes,
-    &DES_EDE3,
+    &DES_EDE3_FOR_LEGACY_USE_ONLY,
     OperatingMode::CBC,
     cbc,
     "0123456789abcdef23456789abcdef01456789abcdef0123",
@@ -1435,10 +1435,10 @@ des_cipher_kat!(
     "2079c3d53aa763e193b79e2569ab5262516570481f25b50f73c0bda85c8e0da7"
 );
 
-#[cfg(feature = "des")]
+#[cfg(feature = "legacy-3des")]
 des_cipher_kat!(
     test_kat_des_ede_ecb_32_bytes,
-    &DES_EDE,
+    &DES_EDE_FOR_LEGACY_USE_ONLY,
     OperatingMode::ECB,
     ecb,
     "0123456789abcdef23456789abcdef01",
@@ -1447,10 +1447,10 @@ des_cipher_kat!(
     "06ede3d82884090aff322c19f0518486730576972a666e58b6c88cf107340d3d"
 );
 
-#[cfg(feature = "des")]
+#[cfg(feature = "legacy-3des")]
 des_cipher_kat!(
     test_kat_des_ede3_ecb_32_bytes,
-    &DES_EDE3,
+    &DES_EDE3_FOR_LEGACY_USE_ONLY,
     OperatingMode::ECB,
     ecb,
     "0123456789abcdef23456789abcdef01456789abcdef0123",
@@ -1459,10 +1459,10 @@ des_cipher_kat!(
     "714772f339841d34267fcc4bd2949cc3ee11c22a576a303876183f99c0b6de87"
 );
 
-#[cfg(feature = "des")]
+#[cfg(feature = "legacy-3des")]
 des_cipher_kat!(
     test_kat_des_ede_cbc_31_bytes,
-    &DES_EDE,
+    &DES_EDE_FOR_LEGACY_USE_ONLY,
     OperatingMode::CBC,
     cbc,
     "0123456789abcdef23456789abcdef01",
@@ -1470,10 +1470,10 @@ des_cipher_kat!(
     "6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e"
 );
 
-#[cfg(feature = "des")]
+#[cfg(feature = "legacy-3des")]
 des_cipher_kat!(
     test_kat_des_ede3_cbc_31_bytes,
-    &DES_EDE3,
+    &DES_EDE3_FOR_LEGACY_USE_ONLY,
     OperatingMode::CBC,
     cbc,
     "0123456789abcdef23456789abcdef01456789abcdef0123",
@@ -1481,10 +1481,10 @@ des_cipher_kat!(
     "6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e"
 );
 
-#[cfg(feature = "des")]
+#[cfg(feature = "legacy-3des")]
 des_cipher_kat!(
     test_kat_des_ede_ecb_31_bytes,
-    &DES_EDE,
+    &DES_EDE_FOR_LEGACY_USE_ONLY,
     OperatingMode::ECB,
     ecb,
     "0123456789abcdef23456789abcdef01",
@@ -1492,10 +1492,10 @@ des_cipher_kat!(
     "6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e"
 );
 
-#[cfg(feature = "des")]
+#[cfg(feature = "legacy-3des")]
 des_cipher_kat!(
     test_kat_des_ede3_ecb_31_bytes,
-    &DES_EDE3,
+    &DES_EDE3_FOR_LEGACY_USE_ONLY,
     OperatingMode::ECB,
     ecb,
     "0123456789abcdef23456789abcdef01456789abcdef0123",
@@ -1503,50 +1503,50 @@ des_cipher_kat!(
     "6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e"
 );
 
-#[cfg(feature = "des")]
+#[cfg(feature = "legacy-3des")]
 des_cipher_rt!(
     test_rt_des_ede_cbc_32_bytes,
-    &DES_EDE,
+    &DES_EDE_FOR_LEGACY_USE_ONLY,
     OperatingMode::CBC,
     cbc,
     "0123456789abcdef23456789abcdef01",
     "4e6f77206973207468652074696d6520666f7220616c6c20206d656e20746f20"
 );
 
-#[cfg(feature = "des")]
+#[cfg(feature = "legacy-3des")]
 des_cipher_rt!(
     test_rt_des_ede3_cbc_32_bytes,
-    &DES_EDE3,
+    &DES_EDE3_FOR_LEGACY_USE_ONLY,
     OperatingMode::CBC,
     cbc,
     "0123456789abcdef23456789abcdef01456789abcdef0123",
     "4e6f77206973207468652074696d6520666f7220616c6c20206d656e20746f20"
 );
 
-#[cfg(feature = "des")]
+#[cfg(feature = "legacy-3des")]
 des_cipher_rt!(
     test_rt_des_ede_ecb_32_bytes,
-    &DES_EDE,
+    &DES_EDE_FOR_LEGACY_USE_ONLY,
     OperatingMode::ECB,
     ecb,
     "0123456789abcdef23456789abcdef01",
     "4e6f77206973207468652074696d6520666f7220616c6c20206d656e20746f20"
 );
 
-#[cfg(feature = "des")]
+#[cfg(feature = "legacy-3des")]
 des_cipher_rt!(
     test_rt_des_ede3_ecb_32_bytes,
-    &DES_EDE3,
+    &DES_EDE3_FOR_LEGACY_USE_ONLY,
     OperatingMode::ECB,
     ecb,
     "0123456789abcdef23456789abcdef01456789abcdef0123",
     "4e6f77206973207468652074696d6520666f7220616c6c20206d656e20746f20"
 );
 
-#[cfg(feature = "des")]
+#[cfg(feature = "legacy-3des")]
 des_padded_cipher_kat!(
     test_kat_des_ede_cbc_pkcs7_32_bytes,
-    &DES_EDE,
+    &DES_EDE_FOR_LEGACY_USE_ONLY,
     OperatingMode::CBC,
     cbc_pkcs7,
     "0123456789abcdef23456789abcdef01",
@@ -1555,10 +1555,10 @@ des_padded_cipher_kat!(
     "7401ce1eab6d003caff84bf47b36cc2154f0238f9ffecd8f6acf118392b45581dcb0d2607c9dd8a3"
 );
 
-#[cfg(feature = "des")]
+#[cfg(feature = "legacy-3des")]
 des_padded_cipher_kat!(
     test_kat_des_ede3_cbc_pkcs7_32_bytes,
-    &DES_EDE3,
+    &DES_EDE3_FOR_LEGACY_USE_ONLY,
     OperatingMode::CBC,
     cbc_pkcs7,
     "0123456789abcdef23456789abcdef01456789abcdef0123",
@@ -1567,10 +1567,10 @@ des_padded_cipher_kat!(
     "2079c3d53aa763e193b79e2569ab5262516570481f25b50f73c0bda85c8e0da733830d1a78387028"
 );
 
-#[cfg(feature = "des")]
+#[cfg(feature = "legacy-3des")]
 des_padded_cipher_kat!(
     test_kat_des_ede_ecb_pkcs7_32_bytes,
-    &DES_EDE,
+    &DES_EDE_FOR_LEGACY_USE_ONLY,
     OperatingMode::ECB,
     ecb_pkcs7,
     "0123456789abcdef23456789abcdef01",
@@ -1579,10 +1579,10 @@ des_padded_cipher_kat!(
     "06ede3d82884090aff322c19f0518486730576972a666e58b6c88cf107340d3d5db28100613ac225"
 );
 
-#[cfg(feature = "des")]
+#[cfg(feature = "legacy-3des")]
 des_padded_cipher_kat!(
     test_kat_des_ede3_ecb_pkcs7_32_bytes,
-    &DES_EDE3,
+    &DES_EDE3_FOR_LEGACY_USE_ONLY,
     OperatingMode::ECB,
     ecb_pkcs7,
     "0123456789abcdef23456789abcdef01456789abcdef0123",
@@ -1591,40 +1591,40 @@ des_padded_cipher_kat!(
     "714772f339841d34267fcc4bd2949cc3ee11c22a576a303876183f99c0b6de87832846b52f9e213d"
 );
 
-#[cfg(feature = "des")]
+#[cfg(feature = "legacy-3des")]
 des_padded_cipher_rt!(
     test_rt_des_ede_cbc_pkcs7_31_bytes,
-    &DES_EDE,
+    &DES_EDE_FOR_LEGACY_USE_ONLY,
     OperatingMode::CBC,
     cbc_pkcs7,
     "0123456789abcdef23456789abcdef01",
     "4e6f77206973207468652074696d6520666f7220616c6c20206d656e20746f"
 );
 
-#[cfg(feature = "des")]
+#[cfg(feature = "legacy-3des")]
 des_padded_cipher_rt!(
     test_rt_des_ede3_cbc_pkcs7_31_bytes,
-    &DES_EDE3,
+    &DES_EDE3_FOR_LEGACY_USE_ONLY,
     OperatingMode::CBC,
     cbc_pkcs7,
     "0123456789abcdef23456789abcdef01456789abcdef0123",
     "4e6f77206973207468652074696d6520666f7220616c6c20206d656e20746f"
 );
 
-#[cfg(feature = "des")]
+#[cfg(feature = "legacy-3des")]
 des_padded_cipher_rt!(
     test_rt_des_ede_ecb_pkcs7_31_bytes,
-    &DES_EDE,
+    &DES_EDE_FOR_LEGACY_USE_ONLY,
     OperatingMode::ECB,
     ecb_pkcs7,
     "0123456789abcdef23456789abcdef01",
     "4e6f77206973207468652074696d6520666f7220616c6c20206d656e20746f"
 );
 
-#[cfg(feature = "des")]
+#[cfg(feature = "legacy-3des")]
 des_padded_cipher_rt!(
     test_rt_des_ede3_ecb_pkcs7_31_bytes,
-    &DES_EDE3,
+    &DES_EDE3_FOR_LEGACY_USE_ONLY,
     OperatingMode::ECB,
     ecb_pkcs7,
     "0123456789abcdef23456789abcdef01456789abcdef0123",

--- a/aws-lc-rs/tests/cipher_test.rs
+++ b/aws-lc-rs/tests/cipher_test.rs
@@ -6,6 +6,9 @@ use aws_lc_rs::cipher::{
     PaddedBlockDecryptingKey, PaddedBlockEncryptingKey, StreamingDecryptingKey,
     StreamingEncryptingKey, UnboundCipherKey, AES_128, AES_192, AES_256,
 };
+#[cfg(feature = "des")]
+#[allow(deprecated)]
+use aws_lc_rs::cipher::{DES_EDE, DES_EDE3};
 use aws_lc_rs::iv::{FixedLength, IV_LEN_128_BIT};
 use aws_lc_rs::test;
 use aws_lc_rs::test::from_hex;
@@ -1109,6 +1112,523 @@ unpadded_cipher_kat!(
     "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
     "00000000000000000000000000000000",
     "00112233445566778899aabbccddee"
+);
+
+#[cfg(feature = "des")]
+macro_rules! des_streaming_cipher_kat {
+    ($name:ident, $alg:expr, $mode:expr, ecb_pkcs7, $key:literal, $plaintext:literal, $ciphertext:literal, $from_step:literal, $to_step:literal) => {
+        paste! {
+        #[allow(deprecated)]
+        #[test]
+        fn [<$name _streaming>]() {
+            let key = from_hex($key).unwrap();
+            let input = from_hex($plaintext).unwrap();
+            let expected_ciphertext = from_hex($ciphertext).unwrap();
+
+            for step in ($from_step..=$to_step) {
+                let unbound_key = UnboundCipherKey::new($alg, &key).unwrap();
+                let encrypting_key = StreamingEncryptingKey::ecb_pkcs7(unbound_key).unwrap();
+
+                let (ciphertext, decrypt_ctx) = step_encrypt(encrypting_key, &input, step);
+
+                assert_eq!(expected_ciphertext.as_slice(), ciphertext.as_ref());
+
+                let unbound_key2 = UnboundCipherKey::new($alg, &key).unwrap();
+                let decrypting_key =
+                    StreamingDecryptingKey::ecb_pkcs7(unbound_key2, decrypt_ctx).unwrap();
+
+                let plaintext = step_decrypt(decrypting_key, &ciphertext, step);
+                assert_eq!(input.as_slice(), plaintext.as_ref());
+            }
+        }
+        }
+    };
+
+    ($name:ident, $alg:expr, $mode:expr, $constructor:ident, $key:literal, $iv:literal, $plaintext:literal, $ciphertext:literal, $from_step:literal, $to_step:literal) => {
+        paste! {
+        #[allow(deprecated)]
+        #[test]
+        fn [<$name _streaming>]() {
+            let key = from_hex($key).unwrap();
+            let input = from_hex($plaintext).unwrap();
+            let expected_ciphertext = from_hex($ciphertext).unwrap();
+            let iv = from_hex($iv).unwrap();
+
+            for step in ($from_step..=$to_step) {
+                let iv_arr: [u8; 8] = iv.clone().try_into().unwrap();
+                let ec = EncryptionContext::Iv64(FixedLength::from(iv_arr));
+
+                let unbound_key = UnboundCipherKey::new($alg, &key).unwrap();
+                let encrypting_key = StreamingEncryptingKey::[<less_safe_ $constructor>](unbound_key, ec).unwrap();
+
+                let (ciphertext, decrypt_ctx) = step_encrypt(encrypting_key, &input, step);
+
+                assert_eq!(expected_ciphertext.as_slice(), ciphertext.as_ref());
+
+                let unbound_key2 = UnboundCipherKey::new($alg, &key).unwrap();
+                let decrypting_key =
+                    StreamingDecryptingKey::$constructor(unbound_key2, decrypt_ctx).unwrap();
+
+                let plaintext = step_decrypt(decrypting_key, &ciphertext, step);
+                assert_eq!(input.as_slice(), plaintext.as_ref());
+            }
+        }
+        }
+    };
+}
+
+#[cfg(feature = "des")]
+macro_rules! des_streaming_cipher_rt {
+    ($name:ident, $alg:expr, $mode:expr, $constructor:ident, $key:literal, $plaintext:literal, $from_step:literal, $to_step:literal) => {
+        paste! {
+        #[allow(deprecated)]
+        #[test]
+        fn [<$name _streaming>]() {
+            let key = from_hex($key).unwrap();
+            let input = from_hex($plaintext).unwrap();
+
+            for step in ($from_step..=$to_step) {
+                let unbound_key = UnboundCipherKey::new($alg, &key).unwrap();
+                let encrypting_key = StreamingEncryptingKey::$constructor(unbound_key).unwrap();
+
+                let (ciphertext, decrypt_ctx) = step_encrypt(encrypting_key, &input, step);
+
+                let unbound_key2 = UnboundCipherKey::new($alg, &key).unwrap();
+                let decrypting_key =
+                    StreamingDecryptingKey::$constructor(unbound_key2, decrypt_ctx).unwrap();
+
+                let plaintext = step_decrypt(decrypting_key, &ciphertext, step);
+                assert_eq!(input.as_slice(), plaintext.as_ref());
+            }
+        }
+        }
+    };
+}
+
+#[cfg(feature = "des")]
+macro_rules! des_cipher_kat {
+    ($name:ident, $alg:expr, $mode:expr, $constructor:ident, $key:literal, $iv:literal, $plaintext:literal, $ciphertext:literal) => {
+        #[allow(deprecated)]
+        #[test]
+        fn $name() {
+            let key = from_hex($key).unwrap();
+            let input = from_hex($plaintext).unwrap();
+            let expected_ciphertext = from_hex($ciphertext).unwrap();
+
+            let enc_ctx = if $iv.len() == 0 {
+                EncryptionContext::None
+            } else {
+                let iv_arr: [u8; 8] = from_hex($iv).unwrap().try_into().unwrap();
+                EncryptionContext::Iv64(FixedLength::from(iv_arr))
+            };
+
+            let unbound_key = UnboundCipherKey::new($alg, &key).unwrap();
+            let encrypting_key = EncryptingKey::$constructor(unbound_key).unwrap();
+            assert_eq!($mode, encrypting_key.mode());
+            assert_eq!($alg, encrypting_key.algorithm());
+            let mut in_out = input.clone();
+            let context = encrypting_key
+                .less_safe_encrypt(&mut in_out, enc_ctx)
+                .unwrap();
+            assert_eq!(expected_ciphertext.as_slice(), in_out.as_slice());
+
+            let unbound_key2 = UnboundCipherKey::new($alg, &key).unwrap();
+            let decrypting_key = DecryptingKey::$constructor(unbound_key2).unwrap();
+            assert_eq!($mode, decrypting_key.mode());
+            assert_eq!($alg, decrypting_key.algorithm());
+            let plaintext = decrypting_key.decrypt(&mut in_out, context).unwrap();
+            assert_eq!(input.as_slice(), plaintext);
+        }
+    };
+
+    ($name:ident, $alg:expr, $mode:expr, $constructor:ident, $key:literal, $iv:literal, $plaintext:literal) => {
+        #[allow(deprecated)]
+        #[test]
+        fn $name() {
+            let key = from_hex($key).unwrap();
+            let input = from_hex($plaintext).unwrap();
+
+            let enc_ctx = if $iv.len() == 0 {
+                EncryptionContext::None
+            } else {
+                let iv_arr: [u8; 8] = from_hex($iv).unwrap().try_into().unwrap();
+                EncryptionContext::Iv64(FixedLength::from(iv_arr))
+            };
+
+            let unbound_key = UnboundCipherKey::new($alg, &key).unwrap();
+            let encrypting_key = EncryptingKey::$constructor(unbound_key).unwrap();
+            assert_eq!($mode, encrypting_key.mode());
+            assert_eq!($alg, encrypting_key.algorithm());
+            let mut in_out = input.clone();
+            encrypting_key
+                .less_safe_encrypt(in_out.as_mut_slice(), enc_ctx)
+                .expect_err("expected encryption failure");
+        }
+    };
+}
+
+#[cfg(feature = "des")]
+macro_rules! des_padded_cipher_kat {
+    ($name:ident, $alg:expr, $mode:expr, ecb_pkcs7, $key:literal, $iv:literal, $plaintext:literal, $ciphertext:literal) => {
+        #[allow(deprecated)]
+        #[test]
+        fn $name() {
+            let key = from_hex($key).unwrap();
+            let input = from_hex($plaintext).unwrap();
+            let expected_ciphertext = from_hex($ciphertext).unwrap();
+
+            let unbound_key = UnboundCipherKey::new($alg, &key).unwrap();
+            let encrypting_key = PaddedBlockEncryptingKey::ecb_pkcs7(unbound_key).unwrap();
+            assert_eq!($mode, encrypting_key.mode());
+            assert_eq!($alg, encrypting_key.algorithm());
+            let mut in_out = input.clone();
+            let context = encrypting_key
+                .less_safe_encrypt(&mut in_out, EncryptionContext::None)
+                .unwrap();
+            assert_eq!(expected_ciphertext.as_slice(), in_out.as_slice());
+
+            let unbound_key2 = UnboundCipherKey::new($alg, &key).unwrap();
+            let decrypting_key = PaddedBlockDecryptingKey::ecb_pkcs7(unbound_key2).unwrap();
+            assert_eq!($mode, decrypting_key.mode());
+            assert_eq!($alg, decrypting_key.algorithm());
+            let plaintext = decrypting_key.decrypt(&mut in_out, context).unwrap();
+            assert_eq!(input.as_slice(), plaintext);
+        }
+
+        des_streaming_cipher_kat!(
+            $name,
+            $alg,
+            $mode,
+            ecb_pkcs7,
+            $key,
+            $plaintext,
+            $ciphertext,
+            2,
+            9
+        );
+    };
+
+    ($name:ident, $alg:expr, $mode:expr, $constructor:ident, $key:literal, $iv:literal, $plaintext:literal, $ciphertext:literal) => {
+        #[allow(deprecated)]
+        #[test]
+        fn $name() {
+            let key = from_hex($key).unwrap();
+            let input = from_hex($plaintext).unwrap();
+            let expected_ciphertext = from_hex($ciphertext).unwrap();
+
+            let enc_ctx = if $iv.len() == 0 {
+                EncryptionContext::None
+            } else {
+                let iv_arr: [u8; 8] = from_hex($iv).unwrap().try_into().unwrap();
+                EncryptionContext::Iv64(FixedLength::from(iv_arr))
+            };
+
+            let unbound_key = UnboundCipherKey::new($alg, &key).unwrap();
+            let encrypting_key = PaddedBlockEncryptingKey::$constructor(unbound_key).unwrap();
+            assert_eq!($mode, encrypting_key.mode());
+            assert_eq!($alg, encrypting_key.algorithm());
+            let mut in_out = input.clone();
+            let context = encrypting_key
+                .less_safe_encrypt(&mut in_out, enc_ctx)
+                .unwrap();
+            assert_eq!(expected_ciphertext.as_slice(), in_out.as_slice());
+
+            let unbound_key2 = UnboundCipherKey::new($alg, &key).unwrap();
+            let decrypting_key = PaddedBlockDecryptingKey::$constructor(unbound_key2).unwrap();
+            assert_eq!($mode, decrypting_key.mode());
+            assert_eq!($alg, decrypting_key.algorithm());
+            let plaintext = decrypting_key.decrypt(&mut in_out, context).unwrap();
+            assert_eq!(input.as_slice(), plaintext);
+        }
+
+        des_streaming_cipher_kat!(
+            $name,
+            $alg,
+            $mode,
+            $constructor,
+            $key,
+            $iv,
+            $plaintext,
+            $ciphertext,
+            2,
+            9
+        );
+    };
+}
+
+#[cfg(feature = "des")]
+macro_rules! des_cipher_rt {
+    ($name:ident, $alg:expr, $mode:expr, $constructor:ident, $key:literal, $plaintext:literal) => {
+        #[allow(deprecated)]
+        #[test]
+        fn $name() {
+            let key = from_hex($key).unwrap();
+            let input = from_hex($plaintext).unwrap();
+
+            let unbound_key = UnboundCipherKey::new($alg, &key).unwrap();
+            let encrypting_key = EncryptingKey::$constructor(unbound_key).unwrap();
+            assert_eq!($mode, encrypting_key.mode());
+            assert_eq!($alg, encrypting_key.algorithm());
+            let mut in_out = input.clone();
+            let context = encrypting_key.encrypt(in_out.as_mut_slice()).unwrap();
+            assert_ne!(input.as_slice(), in_out.as_slice());
+
+            let unbound_key2 = UnboundCipherKey::new($alg, &key).unwrap();
+            let decrypting_key = DecryptingKey::$constructor(unbound_key2).unwrap();
+            assert_eq!($mode, decrypting_key.mode());
+            assert_eq!($alg, decrypting_key.algorithm());
+            let plaintext = decrypting_key.decrypt(&mut in_out, context).unwrap();
+            assert_eq!(input.as_slice(), plaintext);
+        }
+    };
+}
+
+#[cfg(feature = "des")]
+macro_rules! des_padded_cipher_rt {
+    ($name:ident, $alg:expr, $mode:expr, $constructor:ident, $key:literal, $plaintext:literal) => {
+        #[allow(deprecated)]
+        #[test]
+        fn $name() {
+            let key = from_hex($key).unwrap();
+            let input = from_hex($plaintext).unwrap();
+
+            let unbound_key = UnboundCipherKey::new($alg, &key).unwrap();
+            let encrypting_key = PaddedBlockEncryptingKey::$constructor(unbound_key).unwrap();
+            assert_eq!($mode, encrypting_key.mode());
+            assert_eq!($alg, encrypting_key.algorithm());
+            let mut in_out = input.clone();
+            let context = encrypting_key.encrypt(&mut in_out).unwrap();
+
+            let unbound_key2 = UnboundCipherKey::new($alg, &key).unwrap();
+            let decrypting_key = PaddedBlockDecryptingKey::$constructor(unbound_key2).unwrap();
+            assert_eq!($mode, decrypting_key.mode());
+            assert_eq!($alg, decrypting_key.algorithm());
+            let plaintext = decrypting_key.decrypt(&mut in_out, context).unwrap();
+            assert_eq!(input.as_slice(), plaintext);
+        }
+
+        des_streaming_cipher_rt!($name, $alg, $mode, $constructor, $key, $plaintext, 2, 9);
+    };
+}
+
+#[cfg(feature = "des")]
+des_cipher_kat!(
+    test_kat_des_ede_cbc_32_bytes,
+    &DES_EDE,
+    OperatingMode::CBC,
+    cbc,
+    "0123456789abcdef23456789abcdef01",
+    "f69f2445df4f9b17",
+    "6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e51",
+    "7401ce1eab6d003caff84bf47b36cc2154f0238f9ffecd8f6acf118392b45581"
+);
+
+#[cfg(feature = "des")]
+des_cipher_kat!(
+    test_kat_des_ede3_cbc_32_bytes,
+    &DES_EDE3,
+    OperatingMode::CBC,
+    cbc,
+    "0123456789abcdef23456789abcdef01456789abcdef0123",
+    "f69f2445df4f9b17",
+    "6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e51",
+    "2079c3d53aa763e193b79e2569ab5262516570481f25b50f73c0bda85c8e0da7"
+);
+
+#[cfg(feature = "des")]
+des_cipher_kat!(
+    test_kat_des_ede_ecb_32_bytes,
+    &DES_EDE,
+    OperatingMode::ECB,
+    ecb,
+    "0123456789abcdef23456789abcdef01",
+    "",
+    "6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e51",
+    "06ede3d82884090aff322c19f0518486730576972a666e58b6c88cf107340d3d"
+);
+
+#[cfg(feature = "des")]
+des_cipher_kat!(
+    test_kat_des_ede3_ecb_32_bytes,
+    &DES_EDE3,
+    OperatingMode::ECB,
+    ecb,
+    "0123456789abcdef23456789abcdef01456789abcdef0123",
+    "",
+    "6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e51",
+    "714772f339841d34267fcc4bd2949cc3ee11c22a576a303876183f99c0b6de87"
+);
+
+#[cfg(feature = "des")]
+des_cipher_kat!(
+    test_kat_des_ede_cbc_31_bytes,
+    &DES_EDE,
+    OperatingMode::CBC,
+    cbc,
+    "0123456789abcdef23456789abcdef01",
+    "f69f2445df4f9b17",
+    "6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e"
+);
+
+#[cfg(feature = "des")]
+des_cipher_kat!(
+    test_kat_des_ede3_cbc_31_bytes,
+    &DES_EDE3,
+    OperatingMode::CBC,
+    cbc,
+    "0123456789abcdef23456789abcdef01456789abcdef0123",
+    "f69f2445df4f9b17",
+    "6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e"
+);
+
+#[cfg(feature = "des")]
+des_cipher_kat!(
+    test_kat_des_ede_ecb_31_bytes,
+    &DES_EDE,
+    OperatingMode::ECB,
+    ecb,
+    "0123456789abcdef23456789abcdef01",
+    "",
+    "6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e"
+);
+
+#[cfg(feature = "des")]
+des_cipher_kat!(
+    test_kat_des_ede3_ecb_31_bytes,
+    &DES_EDE3,
+    OperatingMode::ECB,
+    ecb,
+    "0123456789abcdef23456789abcdef01456789abcdef0123",
+    "",
+    "6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e"
+);
+
+#[cfg(feature = "des")]
+des_cipher_rt!(
+    test_rt_des_ede_cbc_32_bytes,
+    &DES_EDE,
+    OperatingMode::CBC,
+    cbc,
+    "0123456789abcdef23456789abcdef01",
+    "4e6f77206973207468652074696d6520666f7220616c6c20206d656e20746f20"
+);
+
+#[cfg(feature = "des")]
+des_cipher_rt!(
+    test_rt_des_ede3_cbc_32_bytes,
+    &DES_EDE3,
+    OperatingMode::CBC,
+    cbc,
+    "0123456789abcdef23456789abcdef01456789abcdef0123",
+    "4e6f77206973207468652074696d6520666f7220616c6c20206d656e20746f20"
+);
+
+#[cfg(feature = "des")]
+des_cipher_rt!(
+    test_rt_des_ede_ecb_32_bytes,
+    &DES_EDE,
+    OperatingMode::ECB,
+    ecb,
+    "0123456789abcdef23456789abcdef01",
+    "4e6f77206973207468652074696d6520666f7220616c6c20206d656e20746f20"
+);
+
+#[cfg(feature = "des")]
+des_cipher_rt!(
+    test_rt_des_ede3_ecb_32_bytes,
+    &DES_EDE3,
+    OperatingMode::ECB,
+    ecb,
+    "0123456789abcdef23456789abcdef01456789abcdef0123",
+    "4e6f77206973207468652074696d6520666f7220616c6c20206d656e20746f20"
+);
+
+#[cfg(feature = "des")]
+des_padded_cipher_kat!(
+    test_kat_des_ede_cbc_pkcs7_32_bytes,
+    &DES_EDE,
+    OperatingMode::CBC,
+    cbc_pkcs7,
+    "0123456789abcdef23456789abcdef01",
+    "f69f2445df4f9b17",
+    "6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e51",
+    "7401ce1eab6d003caff84bf47b36cc2154f0238f9ffecd8f6acf118392b45581dcb0d2607c9dd8a3"
+);
+
+#[cfg(feature = "des")]
+des_padded_cipher_kat!(
+    test_kat_des_ede3_cbc_pkcs7_32_bytes,
+    &DES_EDE3,
+    OperatingMode::CBC,
+    cbc_pkcs7,
+    "0123456789abcdef23456789abcdef01456789abcdef0123",
+    "f69f2445df4f9b17",
+    "6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e51",
+    "2079c3d53aa763e193b79e2569ab5262516570481f25b50f73c0bda85c8e0da733830d1a78387028"
+);
+
+#[cfg(feature = "des")]
+des_padded_cipher_kat!(
+    test_kat_des_ede_ecb_pkcs7_32_bytes,
+    &DES_EDE,
+    OperatingMode::ECB,
+    ecb_pkcs7,
+    "0123456789abcdef23456789abcdef01",
+    "",
+    "6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e51",
+    "06ede3d82884090aff322c19f0518486730576972a666e58b6c88cf107340d3d5db28100613ac225"
+);
+
+#[cfg(feature = "des")]
+des_padded_cipher_kat!(
+    test_kat_des_ede3_ecb_pkcs7_32_bytes,
+    &DES_EDE3,
+    OperatingMode::ECB,
+    ecb_pkcs7,
+    "0123456789abcdef23456789abcdef01456789abcdef0123",
+    "",
+    "6bc1bee22e409f96e93d7e117393172aae2d8a571e03ac9c9eb76fac45af8e51",
+    "714772f339841d34267fcc4bd2949cc3ee11c22a576a303876183f99c0b6de87832846b52f9e213d"
+);
+
+#[cfg(feature = "des")]
+des_padded_cipher_rt!(
+    test_rt_des_ede_cbc_pkcs7_31_bytes,
+    &DES_EDE,
+    OperatingMode::CBC,
+    cbc_pkcs7,
+    "0123456789abcdef23456789abcdef01",
+    "4e6f77206973207468652074696d6520666f7220616c6c20206d656e20746f"
+);
+
+#[cfg(feature = "des")]
+des_padded_cipher_rt!(
+    test_rt_des_ede3_cbc_pkcs7_31_bytes,
+    &DES_EDE3,
+    OperatingMode::CBC,
+    cbc_pkcs7,
+    "0123456789abcdef23456789abcdef01456789abcdef0123",
+    "4e6f77206973207468652074696d6520666f7220616c6c20206d656e20746f"
+);
+
+#[cfg(feature = "des")]
+des_padded_cipher_rt!(
+    test_rt_des_ede_ecb_pkcs7_31_bytes,
+    &DES_EDE,
+    OperatingMode::ECB,
+    ecb_pkcs7,
+    "0123456789abcdef23456789abcdef01",
+    "4e6f77206973207468652074696d6520666f7220616c6c20206d656e20746f"
+);
+
+#[cfg(feature = "des")]
+des_padded_cipher_rt!(
+    test_rt_des_ede3_ecb_pkcs7_31_bytes,
+    &DES_EDE3,
+    OperatingMode::ECB,
+    ecb_pkcs7,
+    "0123456789abcdef23456789abcdef01456789abcdef0123",
+    "4e6f77206973207468652074696d6520666f7220616c6c20206d656e20746f"
 );
 
 #[test]


### PR DESCRIPTION
### Description of changes:
Adds 2-key and 3-key Triple DES (`DES_EDE_FOR_LEGACY_USE_ONLY` and `DES_EDE3_FOR_LEGACY_USE_ONLY`) to the `cipher` module, gated behind a new opt-in Cargo feature `legacy-3des`. Only CBC and ECB are supported; CTR and CFB128 are rejected at key-construction time.

Everything about 3DES is hidden by default: the module, the `AlgorithmId` variants, the `SymmetricCipherKey` variants, the new `Iv64` cipher-context variant, and all tests are `#[cfg(feature = "legacy-3des")]`-gated. When the feature is enabled, every public item is also `#[deprecated]` so downstream use sites produce a compiler warning, and the naming follows the existing `cmac::TDES_FOR_LEGACY_USE_ONLY` convention.

Key validation is stricter than what the underlying `EVP_des_*` primitives would do on their own:
* Weak DES subkeys (the four SP 800-67 weak keys) are rejected via `DES_set_key` for every subkey.
* 2TDEA requires K1 ≠ K2.
* 3TDEA requires K1, K2, and K3 to be pairwise distinct. Callers who want the `K1 ‖ K2 ‖ K1` form must use the 2TDEA variant rather than encoding 2TDEA as a 24-byte 3TDEA key.

The streaming cipher path passes raw key bytes to the EVP layer (which internally uses `DES_set_key_unchecked`), so a new `UnboundCipherKey::validate_key_material` step runs the same checks before EVP initialization. For non-DES algorithms it is a no-op.

FIPS builds are supported: the native DES calls are wrapped in `indicator_check!`, which observes that the approved-operation counter does not advance and correctly marks the service indicator as unapproved.

### Call-outs:
* **Feature flag posture is intentionally stricter than `cmac`.** `cmac::TDES_FOR_LEGACY_USE_ONLY` is currently unconditional and not deprecation-marked. This PR opts for the opposite (feature-gated, `#[deprecated]`) because the stated expectation is that 3DES should be clearly legacy in the API surface. Happy to discuss whether `cmac` should follow in a separate change.
* **`all-bindings` propagation.** The low-level `DES_*` symbols live in `openssl/des.h`, which is outside the default bindgen allowlist, so `legacy-3des` forces `aws-lc-sys?/all-bindings` on. `aws-lc-fips-sys` always exposes the full binding set, so nothing extra is needed for the FIPS path. The `EVP_des_*` symbols used on the streaming/cmac paths live in `evp.h` and are always available.
* **Small internal error-type refactor.** `SymmetricCipherKey::aes128/192/256/chacha20` and `TryInto<SymmetricCipherKey> for UnboundCipherKey` now return `KeyRejected` instead of `Unspecified`, so the DES validation path can surface a more specific error internally. All of these items are `pub(crate)`, and the `From<KeyRejected> for Unspecified` conversion handles the boundary at the public API, so this is not an API break. Worth a look during review since it is technically unrelated to DES.
* **New `Algorithm::supports_mode`.** Used to reject `(algorithm, mode)` combinations (e.g. 3DES + CTR) at key-construction time rather than deferring to the first encrypt/decrypt call. This is called from `EncryptingKey::new`, `DecryptingKey::new`, the padded variants, and the streaming variants.
* **No 3DES support was added to `aead::quic`.** QUIC header protection doesn't use 3DES; `cipher_new_mask` treats the new `SymmetricCipherKey` variants as an error.

### Testing:
Tested only with the `legacy-3des` feature enabled (default builds are unchanged and covered by the existing test suite).

* SP 800-67 known-answer tests for 2TDEA and 3TDEA in CBC and ECB mode, both via the one-shot `EncryptingKey`/`DecryptingKey` API and via `StreamingEncryptingKey`/`StreamingDecryptingKey` with step sizes 2 through 9 to exercise the EVP update boundaries.
* Round-trip tests on non-block-aligned plaintext for PKCS#7 CBC/ECB.
* Negative tests for all four DES weak keys, rotated through each of the three subkey positions and padded with distinct non-weak fillers so the pairwise-distinctness check does not short-circuit the weak-key check.
* Negative tests for every degenerate 3TDEA configuration (K1 == K2, K2 == K3, K1 == K3) and the 2TDEA K1 == K2 case.
* Negative tests for CTR and CFB128 on both encrypt and decrypt paths.
* Full library test suite passes with and without `legacy-3des`, and under `--features fips,legacy-3des`.
* `cargo clippy` is clean with the feature enabled.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and the ISC license.
